### PR TITLE
[NCL-6733] && [NCL-6734] Fixed HeaderTools dropdown warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# IntelliJ
+*.iml
+.idea
+
 # dependencies
 /node_modules
 /.pnp

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -44,12 +44,8 @@ export const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => 
     const [currentUser, setCurrentUser] = useState<any>(null);
 
     const headerConfigDropdownItems = [
-      <Link to="/admin/variables">
-        <DropdownItem key="variables">Variables</DropdownItem>
-      </Link>,
-      <Link to="/admin/administration">
-        <DropdownItem key="administration">Administration</DropdownItem>
-      </Link>,
+      <DropdownItem component={<Link to="/admin/variables">Variables</Link>} key="variables" />,
+      <DropdownItem component={<Link to="/admin/administration">Administration</Link>} key="administration" />,
     ];
 
     const headerQuestionDropdownItems = [


### PR DESCRIPTION
Apart from fixing the two warnings, this PR also fixes a small visual bug where having a DropdownItem inside a Link component caused the UI element to be underlined when hovered - this was inconsistent since other Header items do not behave in such a way.