### PR TITLE
[NCL-6752] Implement auth service

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!-- load PNC Web Config from Orch -->
     <script type="text/javascript" src="%REACT_APP_PNC_WEB_CONFIG_JS%/pnc-web-config/config.js"></script>
+    <script type="text/javascript" src="%REACT_APP_KEYCLOAK_URL%/auth/js/keycloak.js"></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -24,6 +24,7 @@ import { Link, useLocation } from 'react-router-dom';
 import pncLogoText from './pnc-logo-text.svg';
 import { AboutModalPage } from './components/AboutModalPage/AboutModalPage';
 import * as WebConfigAPI from './services/WebConfigService';
+import { keycloakService } from './services/keycloakService';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -31,6 +32,8 @@ interface IAppLayout {
 
 export const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   const webConfig = WebConfigAPI.getWebConfig();
+
+  const user = keycloakService.getUser();
 
   const AppLogoImage = () => <img src={pncLogoText} alt="Newcastle Build System" />;
 
@@ -41,7 +44,6 @@ export const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => 
     const [isHeaderQuestionOpen, setIsHeaderQuestionOpen] = useState(false);
     const [isHeaderUserOpen, setIsHeaderUserOpen] = useState(false);
     const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
-    const [currentUser, setCurrentUser] = useState<any>(null);
 
     const headerConfigDropdownItems = [
       <DropdownItem component={<Link to="/admin/variables">Variables</Link>} key="variables" />,
@@ -66,15 +68,17 @@ export const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => 
     const headerUserDropdownItems = [<DropdownItem key="logout">Logout</DropdownItem>];
 
     function processLogin() {
-      if (currentUser) {
+      if (user) {
         setIsHeaderUserOpen(!isHeaderUserOpen);
       } else {
-        setCurrentUser({ userName: 'Jhon Doe' });
+        keycloakService.login().catch(() => {
+          throw new Error('Keycloak login failed.');
+        });
       }
     }
 
     function processLogout() {
-      setCurrentUser(null);
+      keycloakService.logout();
       setIsHeaderUserOpen(false);
     }
 
@@ -128,8 +132,8 @@ export const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => 
                 onSelect={processLogout}
                 toggle={
                   <DropdownToggle toggleIndicator={null} icon={<UserIcon />} onToggle={processLogin}>
-                    {currentUser ? currentUser.userName : 'Login'}
-                    {currentUser && <CaretDownIcon />}
+                    {user ? user : 'Login'}
+                    {user && <CaretDownIcon />}
                   </DropdownToggle>
                 }
                 isOpen={isHeaderUserOpen}

--- a/src/__tests__/AppLayout.test.tsx
+++ b/src/__tests__/AppLayout.test.tsx
@@ -2,9 +2,16 @@ import { render } from '@testing-library/react';
 import { AppLayout } from '../AppLayout';
 import { MemoryRouter } from 'react-router-dom';
 
+jest.mock('../services/keycloakService');
+
 window.pnc = {
   config: {
     userGuideUrl: 'https://localhost:3000/',
+    keycloak: {
+      url: 'https://localhost:3000/',
+      realm: 'test',
+      clientId: 'test',
+    },
   },
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import { AppLayout } from './AppLayout';
@@ -6,16 +6,53 @@ import { AppRoutes } from './AppRoutes';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter } from 'react-router-dom';
 import { ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
+import { keycloakService } from './services/keycloakService';
+
+const App = () => {
+  const [isKeycloakInitiated, setIsKeycloakInitiated] = useState<boolean>(false);
+  const [isKeycloakInitFail, setIsKeycloakInitFail] = useState<boolean>(false);
+  const [isKeycloakInitInProcess, setIsKeycloakInitInProcess] = useState<boolean>(true);
+
+  useEffect(() => {
+    keycloakService
+      .isInitialized()
+      .then(() => {
+        setIsKeycloakInitiated(true);
+      })
+      .catch(() => {
+        setIsKeycloakInitFail(true);
+      })
+      .finally(() => {
+        setIsKeycloakInitInProcess(false);
+      });
+  }, []);
+
+  if (isKeycloakInitiated) {
+    return (
+      <ErrorBoundary>
+        <BrowserRouter basename="/pnc-web">
+          <AppLayout>
+            <AppRoutes></AppRoutes>
+          </AppLayout>
+        </BrowserRouter>
+      </ErrorBoundary>
+    );
+  }
+
+  if (isKeycloakInitFail) {
+    return <div>Keycloak initialization failed</div>;
+  }
+
+  if (isKeycloakInitInProcess) {
+    return <div>keycloak initialization</div>;
+  }
+
+  throw new Error('Keycloak initialization state is invalid.');
+};
 
 ReactDOM.render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <BrowserRouter basename="/pnc-web">
-        <AppLayout>
-          <AppRoutes></AppRoutes>
-        </AppLayout>
-      </BrowserRouter>
-    </ErrorBoundary>
+    <App />
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/services/__mocks__/keycloakService.ts
+++ b/src/services/__mocks__/keycloakService.ts
@@ -1,0 +1,50 @@
+class KeycloakServiceMock {
+  private initialized: boolean = false;
+  private user: any;
+  private isLogin: boolean = false;
+  private roles: String[] = ['Admin'];
+
+  constructor() {
+    this.initialized = true;
+  }
+
+  public isInitialized(): Promise<any> {
+    return new Promise<any>((resolve) => {
+      resolve(this.initialized);
+    });
+  }
+
+  public isAuthenticated(): boolean {
+    return this.isLogin;
+  }
+
+  public login(user: String): Promise<any> {
+    this.user = user;
+    this.isLogin = true;
+    return new Promise<any>((resolve) => {
+      resolve(true);
+    });
+  }
+
+  public logout(): void {
+    this.isLogin = false;
+    this.user = undefined;
+  }
+
+  public getToken(): String {
+    return 'example_token';
+  }
+
+  public getUser(): String {
+    return this.user;
+  }
+
+  public hasRealmRole(role: String): boolean {
+    if (this.roles.includes(role)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+export const keycloakService = new KeycloakServiceMock();

--- a/src/services/keycloakService.ts
+++ b/src/services/keycloakService.ts
@@ -1,0 +1,122 @@
+import * as WebConfigAPI from '../services/WebConfigService';
+declare global {
+  interface Window {
+    Keycloak?: any;
+  }
+}
+/**
+ * Enum with possible authentication roles in keycloak.
+ *
+ */
+export enum AUTH_ROLE {
+  Admin = 'admin',
+  User = 'user',
+  System = 'system-user',
+  Power = 'power-user',
+}
+
+/**
+ * Class managing authentication functionality.
+ */
+class KeycloakService {
+  //We can't get KeycloakInstance type because of dynamic loading of keycloak library
+  private keycloakAuth: any;
+
+  private isKeycloakInitialized;
+
+  constructor() {
+    this.isKeycloakInitialized = this.init();
+  }
+
+  /**
+   * Initialize keycloak and create instance.
+   *
+   * @returns Promise
+   */
+  private init(): Promise<any> {
+    const keycloakConfig = WebConfigAPI.getWebConfig().keycloak;
+
+    this.keycloakAuth = window.Keycloak({
+      url: keycloakConfig.url,
+      realm: keycloakConfig.realm,
+      clientId: keycloakConfig.clientId,
+    });
+
+    return new Promise((resolve, reject) => {
+      this.keycloakAuth
+        .init({ onLoad: 'check-sso' })
+        .then(() => {
+          resolve('success');
+        })
+        .catch((errorData: any) => {
+          reject(errorData);
+        });
+    });
+  }
+  /**
+   * Returns promise of keycloak initialization.
+   *
+   * @returns Promise
+   */
+  public isInitialized(): Promise<any> {
+    return this.isKeycloakInitialized;
+  }
+  /**
+   * Returns if user is authenticated.
+   *
+   * @returns true if user is authenticated, otherwise returns false.
+   */
+  public isAuthenticated(): boolean {
+    return this.keycloakAuth.authenticated!;
+  }
+
+  /**
+   * Initiate login process in keycloak.
+   *
+   * @returns Promise
+   */
+  public login(): Promise<any> {
+    return this.keycloakAuth.login();
+  }
+
+  /**
+   * Initiate logout process in keycloak.
+   *
+   * @param redirectUri - uri to redirect after logout
+   */
+  public logout(redirectUri?: String): void {
+    this.keycloakAuth.logout({ redirectUri });
+  }
+
+  /**
+   * Gets keycloak token.
+   *
+   * @returns String with token if user is logged in or returns undefined when not.
+   */
+  public getToken(): String {
+    return this.keycloakAuth.token;
+  }
+
+  /**
+   * Gets user name from keycloak.
+   *
+   * @returns String with username if user is logged in or returns undefined when not.
+   */
+  public getUser(): String {
+    return this.keycloakAuth.idTokenParsed?.preferred_username;
+  }
+
+  /**
+   * Checks if user has required auth role.
+   *
+   * @param role AUTH_ROLE
+   * @returns true when user is logged in and has required role for access, otherwise return false.
+   */
+  public hasRealmRole(role: AUTH_ROLE): boolean {
+    return this.keycloakAuth.hasRealmRole(role);
+  }
+}
+/**
+ * Instance of KeycloakService providing group of Keycloak related API operations.
+ */
+export const keycloakService = new KeycloakService();

--- a/src/services/pncClient.ts
+++ b/src/services/pncClient.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import * as WebConfigAPI from './WebConfigService';
+import { keycloakService } from './keycloakService';
 
 /**
  * Utils class managing http client instance, only one instance is created.
@@ -24,7 +25,11 @@ class PncClient {
 
     httpClient.interceptors.request.use((config) => {
       // perform actions before request is sent
-      console.log('axios request interceptor', config);
+      const token = keycloakService.getToken();
+      if (token) {
+        config.headers = config.headers ?? {};
+        config.headers.Authorization = `Bearer ` + token;
+      }
 
       /*
        * Convert pageIndex to zero based to be compatible with Orch API
@@ -37,7 +42,6 @@ class PncClient {
 
       return config;
     });
-
     return httpClient;
   };
 


### PR DESCRIPTION
You need to specify: `export REACT_APP_KEYCLOAK_URL=https://<deployment-url>.com`
Skeleton is there and working, still need some improvements that I noticed:
- get rid off env var and read keycloak url in html from configuration file
- without kinit aka in private window in protected route is user always unauthenticated and login process is started, it will do it automatically but screen flickers because of this
- methods in keycloak service are redundant really, you can and I guess will call static keycloak instance and call methods on it than creating instance of keycloak service to call them 

anyway, look at it guys and I'm looking forward your feedback