### PR TITLE
[NCL-7243] Add validation to input fields on Project pages (first validation implementation)

### DIFF
--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -30,7 +30,7 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { ActionButton } from '../ActionButton/ActionButton';
 import mockBuildData from './data/mock-build-data.json';
 import { useTitle } from '../../containers/useTitle';
-import { useForm } from '../../containers/useForm';
+import { IFields, useForm } from '../../containers/useForm';
 import { minLength, maxLength } from '../../utils/formValidationHelpers';
 
 const buildRes: Build[] = mockBuildData;
@@ -59,9 +59,9 @@ const formConfig = {
 export const DemoPage = () => {
   useTitle('Demo Page');
 
-  const submitForm = () => {
+  const submitForm = (data: IFields) => {
     console.log('form state when submitted:', {
-      ...fields,
+      ...data,
     });
   };
 

--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -31,6 +31,7 @@ import { ActionButton } from '../ActionButton/ActionButton';
 import mockBuildData from './data/mock-build-data.json';
 import { useTitle } from '../../containers/useTitle';
 import { useForm } from '../../containers/useForm';
+import { minLength, maxLength } from '../../utils/formValidationHelpers';
 
 const buildRes: Build[] = mockBuildData;
 
@@ -48,6 +49,13 @@ export const DemoPage = () => {
       inputFieldA: {
         value: '',
         isRequired: true,
+        validators: [
+          { validator: minLength(2), errorMessage: 'Text must be at least two characters long.' },
+          {
+            validator: maxLength(10),
+            errorMessage: 'Text cannot be longer than 10 characters.',
+          },
+        ],
       },
       textAreaA: {
         value: '',

--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -35,6 +35,27 @@ import { minLength, maxLength } from '../../utils/formValidationHelpers';
 
 const buildRes: Build[] = mockBuildData;
 
+const formConfig = {
+  inputFieldA: {
+    value: '',
+    isRequired: true,
+    validators: [
+      { validator: minLength(2), errorMessage: 'Text must be at least two characters long.' },
+      {
+        validator: maxLength(10),
+        errorMessage: 'Text cannot be longer than 10 characters.',
+      },
+    ],
+  },
+  textAreaA: {
+    value: '',
+  },
+  selectA: {
+    value: '',
+    isRequired: true,
+  },
+};
+
 export const DemoPage = () => {
   useTitle('Demo Page');
 
@@ -44,29 +65,7 @@ export const DemoPage = () => {
     });
   };
 
-  const { fields, onChange, onSubmit, isSubmitDisabled } = useForm(
-    {
-      inputFieldA: {
-        value: '',
-        isRequired: true,
-        validators: [
-          { validator: minLength(2), errorMessage: 'Text must be at least two characters long.' },
-          {
-            validator: maxLength(10),
-            errorMessage: 'Text cannot be longer than 10 characters.',
-          },
-        ],
-      },
-      textAreaA: {
-        value: '',
-      },
-      selectA: {
-        value: '',
-        isRequired: true,
-      },
-    },
-    submitForm
-  );
+  const { fields, onChange, onSubmit, isSubmitDisabled } = useForm(formConfig, submitForm);
 
   const defaultSelectOptions = [{ value: 'Build' }, { value: 'Option' }, { value: 'Project' }, { value: 'Version' }];
 

--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -1,5 +1,23 @@
 import { PageLayout } from '../PageLayout/PageLayout';
-import { Card, CardTitle, CardBody, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import { useState } from 'react';
+import {
+  ActionGroup,
+  Button,
+  Card,
+  CardTitle,
+  CardBody,
+  Flex,
+  Form,
+  FormGroup,
+  FormHelperText,
+  FlexItem,
+  Select,
+  SelectOption,
+  SelectVariant,
+  Tooltip,
+  TextArea,
+  TextInput,
+} from '@patternfly/react-core';
 import { Build } from 'pnc-api-types-ts';
 import { BuildStatus } from '../BuildStatus/BuildStatus';
 import { BuildStatusIcon } from '../BuildStatusIcon/BuildStatusIcon';
@@ -12,14 +30,153 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { ActionButton } from '../ActionButton/ActionButton';
 import mockBuildData from './data/mock-build-data.json';
 import { useTitle } from '../../containers/useTitle';
+import { useForm } from '../../containers/useForm';
 
 const buildRes: Build[] = mockBuildData;
 
 export const DemoPage = () => {
-  useTitle('Demo');
+  useTitle('Demo Page');
+
+  const submitForm = () => {
+    console.log('form state when submitted:', {
+      ...form,
+    });
+  };
+
+  const { form, onChange, onSubmit, isSubmitDisabled } = useForm(
+    {
+      inputFieldA: {
+        value: '',
+        validator: { isRequired: true },
+      },
+      textAreaA: {
+        value: '',
+      },
+      selectA: {
+        value: '',
+        validator: { isRequired: true },
+      },
+    },
+    submitForm
+  );
+
+  const defaultSelectOptions = [{ value: 'Build' }, { value: 'Option' }, { value: 'Project' }, { value: 'Version' }];
+
+  const [selectOptions, setSelectOptions] = useState<any>(defaultSelectOptions);
+  const [isSelectOpen, setIsSelectOpen] = useState<boolean>(false);
+
+  const clearSelection = () => {
+    onChange('selectA', null);
+    setIsSelectOpen(false);
+    setSelectOptions(defaultSelectOptions);
+  };
+
+  const formComponent = (
+    <Card>
+      <CardBody>
+        <div className="w-70">
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+            }}
+          >
+            <FormGroup
+              isRequired
+              label="Input Field"
+              fieldId="inputFieldA"
+              helperText={
+                <FormHelperText isHidden={form.inputFieldA.state !== 'error'} isError>
+                  {form.inputFieldA.errorMessage}
+                </FormHelperText>
+              }
+            >
+              <TextInput
+                isRequired
+                validated={form.inputFieldA.state}
+                type="text"
+                id="inputFieldA"
+                name="inputFieldA"
+                value={form.inputFieldA.value}
+                autoComplete="off"
+                onChange={(text) => {
+                  onChange('inputFieldA', text);
+                }}
+              />
+            </FormGroup>
+            <FormGroup label="Text Area" fieldId="textAreaA">
+              <TextArea
+                id="textAreaA"
+                name="textAreaA"
+                value={form.textAreaA.value}
+                onChange={(text) => {
+                  onChange('textAreaA', text);
+                }}
+                autoResize
+              />
+            </FormGroup>
+            <FormGroup
+              isRequired
+              label="Filtered Select"
+              fieldId="selectA"
+              helperText={
+                <FormHelperText isHidden={form.selectA.state !== 'error'} isError>
+                  {form.selectA.errorMessage}
+                </FormHelperText>
+              }
+            >
+              <Select
+                validated={form.selectA.state}
+                id="selectA"
+                variant={SelectVariant.typeahead}
+                typeAheadAriaLabel="Select an option"
+                onToggle={(isOpen) => {
+                  setIsSelectOpen(isOpen);
+                }}
+                onSelect={(event, selection, isPlaceholder) => {
+                  if (isPlaceholder) clearSelection();
+                  else {
+                    onChange('selectA', selection);
+                    setIsSelectOpen(false);
+                  }
+                }}
+                onClear={clearSelection}
+                selections={form.selectA.value}
+                isOpen={isSelectOpen}
+                aria-labelledby={'selectA'}
+                placeholderText="Select an option"
+              >
+                {selectOptions.map((option: any, index: any) => (
+                  <SelectOption key={index} value={option.value} />
+                ))}
+              </Select>
+            </FormGroup>
+            <ActionGroup>
+              <Button
+                variant="primary"
+                isDisabled={isSubmitDisabled}
+                onClick={() => {
+                  onSubmit();
+                }}
+              >
+                Submit
+              </Button>
+            </ActionGroup>
+          </Form>
+        </div>
+      </CardBody>
+    </Card>
+  );
+
   return (
     <PageLayout title="Component Demo" description="Component demo page intended for showcasing React components.">
       <Flex direction={{ default: 'column' }}>
+        <FlexItem>
+          <Card>
+            <CardTitle>Form Demo</CardTitle>
+            <CardBody>{formComponent}</CardBody>
+          </Card>
+        </FlexItem>
+
         <FlexItem>
           <Card>
             <CardTitle>BuildStatus</CardTitle>
@@ -295,6 +452,7 @@ export const DemoPage = () => {
             </CardBody>
           </Card>
         </FlexItem>
+
         <FlexItem>
           <Card>
             <CardTitle>BuildMetrics</CardTitle>

--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -47,14 +47,14 @@ export const DemoPage = () => {
     {
       inputFieldA: {
         value: '',
-        validator: { isRequired: true },
+        validation: { isRequired: true },
       },
       textAreaA: {
         value: '',
       },
       selectA: {
         value: '',
-        validator: { isRequired: true },
+        validation: { isRequired: true },
       },
     },
     submitForm
@@ -86,7 +86,7 @@ export const DemoPage = () => {
               fieldId="inputFieldA"
               helperText={
                 <FormHelperText isHidden={form.inputFieldA.state !== 'error'} isError>
-                  {form.inputFieldA.errorMessage}
+                  {form.inputFieldA.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >
@@ -120,7 +120,7 @@ export const DemoPage = () => {
               fieldId="selectA"
               helperText={
                 <FormHelperText isHidden={form.selectA.state !== 'error'} isError>
-                  {form.selectA.errorMessage}
+                  {form.selectA.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >

--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -47,14 +47,14 @@ export const DemoPage = () => {
     {
       inputFieldA: {
         value: '',
-        validation: { isRequired: true },
+        isRequired: true,
       },
       textAreaA: {
         value: '',
       },
       selectA: {
         value: '',
-        validation: { isRequired: true },
+        isRequired: true,
       },
     },
     submitForm

--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -40,11 +40,11 @@ export const DemoPage = () => {
 
   const submitForm = () => {
     console.log('form state when submitted:', {
-      ...form,
+      ...fields,
     });
   };
 
-  const { form, onChange, onSubmit, isSubmitDisabled } = useForm(
+  const { fields, onChange, onSubmit, isSubmitDisabled } = useForm(
     {
       inputFieldA: {
         value: '',
@@ -93,18 +93,18 @@ export const DemoPage = () => {
               label="Input Field"
               fieldId="inputFieldA"
               helperText={
-                <FormHelperText isHidden={form.inputFieldA.state !== 'error'} isError>
-                  {form.inputFieldA.errorMessages?.join(' ')}
+                <FormHelperText isHidden={fields.inputFieldA.state !== 'error'} isError>
+                  {fields.inputFieldA.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >
               <TextInput
                 isRequired
-                validated={form.inputFieldA.state}
+                validated={fields.inputFieldA.state}
                 type="text"
                 id="inputFieldA"
                 name="inputFieldA"
-                value={form.inputFieldA.value}
+                value={fields.inputFieldA.value}
                 autoComplete="off"
                 onChange={(text) => {
                   onChange('inputFieldA', text);
@@ -115,7 +115,7 @@ export const DemoPage = () => {
               <TextArea
                 id="textAreaA"
                 name="textAreaA"
-                value={form.textAreaA.value}
+                value={fields.textAreaA.value}
                 onChange={(text) => {
                   onChange('textAreaA', text);
                 }}
@@ -127,13 +127,13 @@ export const DemoPage = () => {
               label="Filtered Select"
               fieldId="selectA"
               helperText={
-                <FormHelperText isHidden={form.selectA.state !== 'error'} isError>
-                  {form.selectA.errorMessages?.join(' ')}
+                <FormHelperText isHidden={fields.selectA.state !== 'error'} isError>
+                  {fields.selectA.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >
               <Select
-                validated={form.selectA.state}
+                validated={fields.selectA.state}
                 id="selectA"
                 variant={SelectVariant.typeahead}
                 typeAheadAriaLabel="Select an option"
@@ -148,7 +148,7 @@ export const DemoPage = () => {
                   }
                 }}
                 onClear={clearSelection}
-                selections={form.selectA.value}
+                selections={fields.selectA.value}
                 isOpen={isSelectOpen}
                 aria-labelledby={'selectA'}
                 placeholderText="Select an option"

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -96,12 +96,12 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
       description: {},
       projectUrl: {
         validation: {
-          validators: [{ check: validateUrl, errorMessage: 'Invalid URL format.' }],
+          validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
         },
       },
       issueTrackerUrl: {
         validation: {
-          validators: [{ check: validateUrl, errorMessage: 'Invalid URL format.' }],
+          validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
         },
       },
       engineeringTeam: {},

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -89,20 +89,14 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
   const { form, onChange, applyValues, onSubmit, isSubmitDisabled } = useForm(
     {
       name: {
-        validation: {
-          isRequired: true,
-        },
+        isRequired: true,
       },
       description: {},
       projectUrl: {
-        validation: {
-          validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
-        },
+        validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
       },
       issueTrackerUrl: {
-        validation: {
-          validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
-        },
+        validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
       },
       engineeringTeam: {},
       technicalLeader: {},

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -163,8 +163,8 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 name="name"
                 value={form.name.value}
                 autoComplete="off"
-                onChange={(name, event) => {
-                  onChange(event);
+                onChange={(name) => {
+                  onChange('name', name);
                 }}
               />
             </FormGroup>
@@ -173,8 +173,8 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 id="description"
                 name="description"
                 value={form.description.value}
-                onChange={(description, event) => {
-                  onChange(event);
+                onChange={(description) => {
+                  onChange('description', description);
                 }}
                 autoResize
               />
@@ -195,8 +195,8 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 name="projectUrl"
                 autoComplete="off"
                 value={form.projectUrl.value}
-                onChange={(url, event) => {
-                  onChange(event);
+                onChange={(url) => {
+                  onChange('projectUrl', url);
                 }}
               />
             </FormGroup>
@@ -216,8 +216,8 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 name="issueTrackerUrl"
                 autoComplete="off"
                 value={form.issueTrackerUrl.value}
-                onChange={(url, event) => {
-                  onChange(event);
+                onChange={(url) => {
+                  onChange('issueTrackerUrl', url);
                 }}
               />
             </FormGroup>
@@ -228,8 +228,8 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 name="engineeringTeam"
                 autoComplete="off"
                 value={form.engineeringTeam.value}
-                onChange={(engineeringTeam, event) => {
-                  onChange(event);
+                onChange={(engineeringTeam) => {
+                  onChange('engineeringTeam', engineeringTeam);
                 }}
               />
             </FormGroup>
@@ -240,8 +240,8 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 name="technicalLeader"
                 autoComplete="off"
                 value={form.technicalLeader.value}
-                onChange={(url, event) => {
-                  onChange(event);
+                onChange={(technicalLeader) => {
+                  onChange('technicalLeader', technicalLeader);
                 }}
               />
             </FormGroup>

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -30,6 +30,21 @@ interface IProjectCreateEditPageProps {
   editPage?: boolean;
 }
 
+const formConfig = {
+  name: {
+    isRequired: true,
+  },
+  description: {},
+  projectUrl: {
+    validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
+  },
+  issueTrackerUrl: {
+    validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
+  },
+  engineeringTeam: {},
+  technicalLeader: {},
+};
+
 export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPageProps) => {
   const flexDirection: FlexProps['direction'] = { default: 'column' };
 
@@ -87,20 +102,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
   };
 
   const { fields, onChange, applyValues, onSubmit, isSubmitDisabled } = useForm(
-    {
-      name: {
-        isRequired: true,
-      },
-      description: {},
-      projectUrl: {
-        validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
-      },
-      issueTrackerUrl: {
-        validators: [{ validator: validateUrl, errorMessage: 'Invalid URL format.' }],
-      },
-      engineeringTeam: {},
-      technicalLeader: {},
-    },
+    formConfig,
     editPage ? submitUpdate : submitCreate
   );
 

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -25,7 +25,7 @@ import { useTitle } from '../../containers/useTitle';
 import { projectService } from '../../services/projectService';
 import { PageLayout } from '../PageLayout/PageLayout';
 import { useForm } from '../../containers/useForm';
-import { validateProjectName, validateUrl } from '../../utils/formValidationHelpers';
+import { validateUrl } from '../../utils/formValidationHelpers';
 
 interface IProjectCreateEditPageProps {
   editPage?: boolean;
@@ -83,7 +83,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
     });
   };
 
-  const { fieldValues, fieldErrors, fieldStates, isFormValid, onChange, setFieldValues, onSubmit } = useForm(
+  const { fieldValues, fieldErrors, fieldStates, isSubmitDisabled, onChange, setFieldValues, onSubmit } = useForm(
     {
       name: '',
       description: '',
@@ -93,9 +93,9 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
       technicalLeader: '',
     },
     {
-      name: validateProjectName,
-      projectUrl: validateUrl,
-      issueTrackerUrl: validateUrl,
+      name: { isRequired: true },
+      projectUrl: { validator: validateUrl },
+      issueTrackerUrl: { validator: validateUrl },
     },
     editPage ? submitUpdate : submitCreate
   );
@@ -192,7 +192,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               fieldId="issueTrackerUrl"
               helperText={
                 <FormHelperText isHidden={fieldStates.issueTrackerUrl !== 'error'} isError>
-                  {fieldErrors.projectUrl}
+                  {fieldErrors.issueTrackerUrl}
                 </FormHelperText>
               }
             >
@@ -235,7 +235,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
             <ActionGroup>
               <Button
                 variant="primary"
-                isDisabled={!isFormValid}
+                isDisabled={isSubmitDisabled}
                 onClick={() => {
                   onSubmit();
                 }}

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -12,7 +12,6 @@ import {
   Label,
   TextArea,
   TextInput,
-  TextInputProps,
 } from '@patternfly/react-core';
 import { Project } from 'pnc-api-types-ts';
 import { useCallback, useEffect, useState } from 'react';
@@ -121,7 +120,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
         throw new Error(`Invalid projectId: ${urlPathParams.projectId}`);
       }
     }
-  }, [editPage, urlPathParams.projectId, editRefresh]);
+  }, [editPage, urlPathParams.projectId, editRefresh, setFieldValues]);
 
   const formComponent = (
     <Card>

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -60,12 +60,12 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
     return dataContainerCreate
       .refresh({
         serviceData: {
-          name: form.name.value,
-          description: form.description.value,
-          projectUrl: form.projectUrl.value,
-          issueTrackerUrl: form.issueTrackerUrl.value,
-          engineeringTeam: form.engineeringTeam.value,
-          technicalLeader: form.technicalLeader.value,
+          name: fields.name.value,
+          description: fields.description.value,
+          projectUrl: fields.projectUrl.value,
+          issueTrackerUrl: fields.issueTrackerUrl.value,
+          engineeringTeam: fields.engineeringTeam.value,
+          technicalLeader: fields.technicalLeader.value,
         },
       })
       .then((response: any) => {
@@ -86,7 +86,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
     });
   };
 
-  const { form, onChange, applyValues, onSubmit, isSubmitDisabled } = useForm(
+  const { fields, onChange, applyValues, onSubmit, isSubmitDisabled } = useForm(
     {
       name: {
         isRequired: true,
@@ -141,18 +141,18 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               label="Name"
               fieldId="name"
               helperText={
-                <FormHelperText isHidden={form.name.state !== 'error'} isError>
-                  {form.name.errorMessages?.join(' ')}
+                <FormHelperText isHidden={fields.name.state !== 'error'} isError>
+                  {fields.name.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >
               <TextInput
                 isRequired
-                validated={form.name.state}
+                validated={fields.name.state}
                 type="text"
                 id="name"
                 name="name"
-                value={form.name.value}
+                value={fields.name.value}
                 autoComplete="off"
                 onChange={(name) => {
                   onChange('name', name);
@@ -163,7 +163,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               <TextArea
                 id="description"
                 name="description"
-                value={form.description.value}
+                value={fields.description.value}
                 onChange={(description) => {
                   onChange('description', description);
                 }}
@@ -174,18 +174,18 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               label="Project URL"
               fieldId="projectUrl"
               helperText={
-                <FormHelperText isHidden={form.projectUrl.state !== 'error'} isError>
-                  {form.projectUrl.errorMessages?.join(' ')}
+                <FormHelperText isHidden={fields.projectUrl.state !== 'error'} isError>
+                  {fields.projectUrl.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >
               <TextInput
-                validated={form.projectUrl.state}
+                validated={fields.projectUrl.state}
                 type="url"
                 id="projectUrl"
                 name="projectUrl"
                 autoComplete="off"
-                value={form.projectUrl.value}
+                value={fields.projectUrl.value}
                 onChange={(url) => {
                   onChange('projectUrl', url);
                 }}
@@ -195,18 +195,18 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               label="Issue Tracker URL"
               fieldId="issueTrackerUrl"
               helperText={
-                <FormHelperText isHidden={form.issueTrackerUrl.state !== 'error'} isError>
-                  {form.issueTrackerUrl.errorMessages?.join(' ')}
+                <FormHelperText isHidden={fields.issueTrackerUrl.state !== 'error'} isError>
+                  {fields.issueTrackerUrl.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >
               <TextInput
-                validated={form.issueTrackerUrl.state}
+                validated={fields.issueTrackerUrl.state}
                 type="url"
                 id="issueTrackerUrl"
                 name="issueTrackerUrl"
                 autoComplete="off"
-                value={form.issueTrackerUrl.value}
+                value={fields.issueTrackerUrl.value}
                 onChange={(url) => {
                   onChange('issueTrackerUrl', url);
                 }}
@@ -218,7 +218,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 id="engineeringTeam"
                 name="engineeringTeam"
                 autoComplete="off"
-                value={form.engineeringTeam.value}
+                value={fields.engineeringTeam.value}
                 onChange={(engineeringTeam) => {
                   onChange('engineeringTeam', engineeringTeam);
                 }}
@@ -230,7 +230,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 id="technicalLeader"
                 name="technicalLeader"
                 autoComplete="off"
-                value={form.technicalLeader.value}
+                value={fields.technicalLeader.value}
                 onChange={(technicalLeader) => {
                   onChange('technicalLeader', technicalLeader);
                 }}

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -23,7 +23,7 @@ import { IService, useDataContainer } from '../../containers/DataContainer/useDa
 import { useTitle } from '../../containers/useTitle';
 import { projectService } from '../../services/projectService';
 import { PageLayout } from '../PageLayout/PageLayout';
-import { useForm } from '../../containers/useForm';
+import { IFields, useForm } from '../../containers/useForm';
 import { validateUrl } from '../../utils/formValidationHelpers';
 
 interface IProjectCreateEditPageProps {
@@ -71,16 +71,16 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
 
   useTitle(editPage ? `Edit | ${PageTitles.projects}` : `Create | ${PageTitles.projects}`);
 
-  const submitCreate = () => {
+  const submitCreate = (data: IFields) => {
     return dataContainerCreate
       .refresh({
         serviceData: {
-          name: fields.name.value,
-          description: fields.description.value,
-          projectUrl: fields.projectUrl.value,
-          issueTrackerUrl: fields.issueTrackerUrl.value,
-          engineeringTeam: fields.engineeringTeam.value,
-          technicalLeader: fields.technicalLeader.value,
+          name: data.name.value,
+          description: data.description.value,
+          projectUrl: data.projectUrl.value,
+          issueTrackerUrl: data.issueTrackerUrl.value,
+          engineeringTeam: data.engineeringTeam.value,
+          technicalLeader: data.technicalLeader.value,
         },
       })
       .then((response: any) => {
@@ -93,11 +93,11 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
       });
   };
 
-  const submitUpdate = () => {
+  const submitUpdate = (data: IFields) => {
     // PATCH method should be used
     console.log('not implemented yet', {
       id,
-      ...fields,
+      ...data,
     });
   };
 

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -56,11 +56,16 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
 
   useTitle(editPage ? `Edit | ${PageTitles.projects}` : `Create | ${PageTitles.projects}`);
 
-  const submitCreate = (data: any) => {
-    dataContainerCreate
+  const submitCreate = () => {
+    return dataContainerCreate
       .refresh({
         serviceData: {
-          ...data,
+          name: form.name.value,
+          description: form.description.value,
+          projectUrl: form.projectUrl.value,
+          issueTrackerUrl: form.issueTrackerUrl.value,
+          engineeringTeam: form.engineeringTeam.value,
+          technicalLeader: form.technicalLeader.value,
         },
       })
       .then((response: any) => {
@@ -70,8 +75,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
         }
         // temporarily navigate to edit page until detail page is finished
         navigate(`/projects/${projectId}/edit`, { replace: true });
-      })
-      .catch((error: any) => {});
+      });
   };
 
   const submitUpdate = (data: any) => {
@@ -82,19 +86,29 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
     });
   };
 
-  const { fieldValues, fieldErrors, fieldStates, isSubmitDisabled, onChange, setFieldValues, onSubmit } = useForm(
+  const { form, onChange, applyValues, onSubmit, isSubmitDisabled } = useForm(
     {
-      name: '',
-      description: '',
-      projectUrl: '',
-      issueTrackerUrl: '',
-      engineeringTeam: '',
-      technicalLeader: '',
-    },
-    {
-      name: { isRequired: true },
-      projectUrl: { validator: validateUrl },
-      issueTrackerUrl: { validator: validateUrl },
+      name: {
+        value: '',
+        validator: { isRequired: true },
+      },
+      description: {
+        value: '',
+      },
+      projectUrl: {
+        value: '',
+        validator: { check: validateUrl },
+      },
+      issueTrackerUrl: {
+        value: '',
+        validator: { check: validateUrl },
+      },
+      engineeringTeam: {
+        value: '',
+      },
+      technicalLeader: {
+        value: '',
+      },
     },
     editPage ? submitUpdate : submitCreate
   );
@@ -106,8 +120,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
           const project: Project = response.data;
 
           setId(project.id);
-          setFieldValues({
-            id: project.id || '',
+          applyValues({
             name: project.name || '',
             description: project.description || '',
             projectUrl: project.projectUrl || '',
@@ -120,7 +133,8 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
         throw new Error(`Invalid projectId: ${urlPathParams.projectId}`);
       }
     }
-  }, [editPage, urlPathParams.projectId, editRefresh, setFieldValues]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editPage]);
 
   const formComponent = (
     <Card>
@@ -136,18 +150,18 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               label="Name"
               fieldId="name"
               helperText={
-                <FormHelperText isHidden={fieldStates.name !== 'error'} isError>
-                  {fieldErrors.name}
+                <FormHelperText isHidden={form.name.state !== 'error'} isError>
+                  {form.name.errorMessage}
                 </FormHelperText>
               }
             >
               <TextInput
                 isRequired
-                validated={fieldStates.name}
+                validated={form.name.state}
                 type="text"
                 id="name"
                 name="name"
-                value={fieldValues.name}
+                value={form.name.value}
                 autoComplete="off"
                 onChange={(name, event) => {
                   onChange(event);
@@ -158,7 +172,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               <TextArea
                 id="description"
                 name="description"
-                value={fieldValues.description}
+                value={form.description.value}
                 onChange={(description, event) => {
                   onChange(event);
                 }}
@@ -169,18 +183,18 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               label="Project URL"
               fieldId="projectUrl"
               helperText={
-                <FormHelperText isHidden={fieldStates.projectUrl !== 'error'} isError>
-                  {fieldErrors.projectUrl}
+                <FormHelperText isHidden={form.projectUrl.state !== 'error'} isError>
+                  {form.projectUrl.errorMessage}
                 </FormHelperText>
               }
             >
               <TextInput
-                validated={fieldStates.projectUrl}
+                validated={form.projectUrl.state}
                 type="url"
                 id="projectUrl"
                 name="projectUrl"
                 autoComplete="off"
-                value={fieldValues.projectUrl}
+                value={form.projectUrl.value}
                 onChange={(url, event) => {
                   onChange(event);
                 }}
@@ -190,18 +204,18 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               label="Issue Tracker URL"
               fieldId="issueTrackerUrl"
               helperText={
-                <FormHelperText isHidden={fieldStates.issueTrackerUrl !== 'error'} isError>
-                  {fieldErrors.issueTrackerUrl}
+                <FormHelperText isHidden={form.issueTrackerUrl.state !== 'error'} isError>
+                  {form.issueTrackerUrl.errorMessage}
                 </FormHelperText>
               }
             >
               <TextInput
-                validated={fieldStates.issueTrackerUrl}
+                validated={form.issueTrackerUrl.state}
                 type="url"
                 id="issueTrackerUrl"
                 name="issueTrackerUrl"
                 autoComplete="off"
-                value={fieldValues.issueTrackerUrl}
+                value={form.issueTrackerUrl.value}
                 onChange={(url, event) => {
                   onChange(event);
                 }}
@@ -213,7 +227,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 id="engineeringTeam"
                 name="engineeringTeam"
                 autoComplete="off"
-                value={fieldValues.engineeringTeam}
+                value={form.engineeringTeam.value}
                 onChange={(engineeringTeam, event) => {
                   onChange(event);
                 }}
@@ -225,7 +239,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
                 id="technicalLeader"
                 name="technicalLeader"
                 autoComplete="off"
-                value={fieldValues.technicalLeader}
+                value={form.technicalLeader.value}
                 onChange={(url, event) => {
                   onChange(event);
                 }}

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -89,26 +89,23 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
   const { form, onChange, applyValues, onSubmit, isSubmitDisabled } = useForm(
     {
       name: {
-        value: '',
-        validator: { isRequired: true },
+        validation: {
+          isRequired: true,
+        },
       },
-      description: {
-        value: '',
-      },
+      description: {},
       projectUrl: {
-        value: '',
-        validator: { check: validateUrl },
+        validation: {
+          validators: [{ check: validateUrl, errorMessage: 'Invalid URL format.' }],
+        },
       },
       issueTrackerUrl: {
-        value: '',
-        validator: { check: validateUrl },
+        validation: {
+          validators: [{ check: validateUrl, errorMessage: 'Invalid URL format.' }],
+        },
       },
-      engineeringTeam: {
-        value: '',
-      },
-      technicalLeader: {
-        value: '',
-      },
+      engineeringTeam: {},
+      technicalLeader: {},
     },
     editPage ? submitUpdate : submitCreate
   );
@@ -151,7 +148,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               fieldId="name"
               helperText={
                 <FormHelperText isHidden={form.name.state !== 'error'} isError>
-                  {form.name.errorMessage}
+                  {form.name.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >
@@ -184,7 +181,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               fieldId="projectUrl"
               helperText={
                 <FormHelperText isHidden={form.projectUrl.state !== 'error'} isError>
-                  {form.projectUrl.errorMessage}
+                  {form.projectUrl.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >
@@ -205,7 +202,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
               fieldId="issueTrackerUrl"
               helperText={
                 <FormHelperText isHidden={form.issueTrackerUrl.state !== 'error'} isError>
-                  {form.issueTrackerUrl.errorMessage}
+                  {form.issueTrackerUrl.errorMessages?.join(' ')}
                 </FormHelperText>
               }
             >

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -101,7 +101,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
     });
   };
 
-  const { fields, onChange, applyValues, onSubmit, isSubmitDisabled } = useForm(
+  const { fields, onChange, reinitialize, onSubmit, isSubmitDisabled } = useForm(
     formConfig,
     editPage ? submitUpdate : submitCreate
   );
@@ -113,7 +113,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
           const project: Project = response.data;
 
           setId(project.id);
-          applyValues({
+          reinitialize({
             name: project.name || '',
             description: project.description || '',
             projectUrl: project.projectUrl || '',
@@ -126,8 +126,7 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
         throw new Error(`Invalid projectId: ${urlPathParams.projectId}`);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editPage]);
+  }, [editPage, urlPathParams.projectId, editRefresh, reinitialize]);
 
   const formComponent = (
     <Card>

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -93,11 +93,11 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
       });
   };
 
-  const submitUpdate = (data: any) => {
+  const submitUpdate = () => {
     // PATCH method should be used
     console.log('not implemented yet', {
       id,
-      ...data,
+      ...fields,
     });
   };
 
@@ -114,12 +114,12 @@ export const ProjectCreateEditPage = ({ editPage = false }: IProjectCreateEditPa
 
           setId(project.id);
           reinitialize({
-            name: project.name || '',
-            description: project.description || '',
-            projectUrl: project.projectUrl || '',
-            issueTrackerUrl: project.issueTrackerUrl || '',
-            engineeringTeam: project.engineeringTeam || '',
-            technicalLeader: project.technicalLeader || '',
+            name: project.name,
+            description: project.description,
+            projectUrl: project.projectUrl,
+            issueTrackerUrl: project.issueTrackerUrl,
+            engineeringTeam: project.engineeringTeam,
+            technicalLeader: project.technicalLeader,
           });
         });
       } else {

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { TextInputProps } from '@patternfly/react-core';
 
 export interface IFieldValues {
   [key: string]: string;
@@ -12,7 +13,7 @@ interface IValidator {
 interface IField {
   value?: string;
   errorMessages?: string[];
-  state?: any;
+  state?: TextInputProps['validated'];
   isRequired?: boolean;
   validators?: IValidator[];
 }
@@ -92,7 +93,12 @@ export const useForm = (initForm: Omit<Omit<IForm, 'errorMessage'>, 'state'>, ca
   // callback (on change of an input)
   const onChange = (fieldName: any, fieldValue: any) => {
     // also delete old error messages, new checks are going to be done
-    const newFieldState = { ...form[fieldName], value: fieldValue, errorMessages: [], state: 'default' };
+    const newFieldState = {
+      ...form[fieldName],
+      value: fieldValue,
+      errorMessages: [],
+      state: 'default' as TextInputProps['validated'],
+    };
     validate(newFieldState);
     setForm({ ...form, [fieldName]: newFieldState });
 

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -60,7 +60,12 @@ export interface IFormState {
  *        -> errorMessage -- error message that should be set in a case of an error
  */
 export const useForm = (initForm: Omit<Omit<IFormState, 'errorMessage'>, 'state'>, callback: Function) => {
-  const [form, setForm] = useState<IFormState>(initForm);
+  const defaultForm = { ...initForm };
+  for (const key in defaultForm) {
+    defaultForm[key].value = '';
+    defaultForm[key].state = 'default';
+  }
+  const [form, setForm] = useState<IFormState>(defaultForm);
 
   // is submit button disabled?
   const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(true);

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -18,7 +18,7 @@ interface IField {
   validators?: IValidator[];
 }
 
-interface IFields {
+export interface IFields {
   [key: string]: IField;
 }
 
@@ -94,13 +94,9 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
   // callback (on change of an input)
   const onChange = (fieldName: string, fieldValue: any) => {
     // also delete old error messages, new checks are going to be done(
-
-    // trim just strings
-    const editedFieldValue = typeof fieldValue == 'string' ? fieldValue.trim() : fieldValue;
-
     const newField = {
       ...fields[fieldName],
-      value: editedFieldValue,
+      value: fieldValue ? fieldValue : '',
       errorMessages: [],
       state: 'default' as TextInputProps['validated'],
     };
@@ -113,7 +109,7 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
   // validate field state and change error messages / state
   const validate = (field: IField) => {
     if (field.isRequired) {
-      const error = field.value ? '' : 'Field must be filled.';
+      const error = field.value?.trim() ? '' : 'Field must be filled.';
       addError(field, error);
       setState(field);
     }
@@ -149,7 +145,15 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
 
   // callback (on submit of a form)
   const onSubmit = () => {
-    submitCallback().catch((error: any) => {
+    const formCopy = { ...fields };
+    for (const key in formCopy) {
+      // trim just strings
+      formCopy[key].value = typeof formCopy[key].value === 'string' ? formCopy[key].value?.trim() : formCopy[key].value;
+      // reset state to 'default' (valid inputs wont be highlighted)
+      formCopy[key].state = 'default';
+    }
+
+    submitCallback(formCopy).catch((error: any) => {
       // backend error, just log it at the moment
       console.error(error);
 
@@ -162,11 +166,6 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
       // setForm(formCopy);
     });
 
-    // reset state to 'default' (valid inputs wont be highlighted)
-    const formCopy = { ...fields };
-    for (const key in formCopy) {
-      formCopy[key].state = 'default';
-    }
     setFields(formCopy);
     setHasChanged(false);
   };

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+
+interface IFieldValues {
+  [key: string]: string;
+}
+
+interface IFieldErros {
+  [key: string]: string | undefined;
+}
+
+interface IFieldValidators {
+  [key: string]: Function;
+}
+
+export const useForm = (initValues: IFieldValues, validators: IFieldValidators, callback: Function) => {
+  const [isFormValid, setIsFormValid] = useState<boolean>(false);
+  const [hasChanged, setHasChanged] = useState<boolean>(false);
+
+  const [fieldValues, setFieldValues] = useState<IFieldValues>(initValues);
+  const [fieldErrors, setFieldErrors] = useState<IFieldErros>({});
+  const [fieldValidators, setFieldValidators] = useState<IFieldValidators>(validators);
+
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  const initFieldStates = { ...initValues };
+  Object.keys(initFieldStates).forEach((key) => {
+    initFieldStates[key] = 'default';
+  });
+  const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
+
+  useEffect(() => {
+    if (!Object.keys(fieldErrors).length && hasChanged) {
+      setIsFormValid(true);
+      if (isSubmitting) {
+        callback(fieldValues);
+        setFieldStates(initFieldStates);
+      }
+    } else {
+      setIsFormValid(false);
+    }
+
+    setIsSubmitting(false);
+  }, [fieldErrors]);
+
+  const onChange = (event: React.FormEvent<HTMLInputElement> | React.FormEvent<HTMLTextAreaElement>) => {
+    const fieldName = event.currentTarget.name;
+    setFieldValues({ ...fieldValues, [fieldName]: event.currentTarget.value });
+    setHasChanged(true);
+
+    if (fieldValidators[fieldName]) {
+      const error = fieldValidators[fieldName](event.currentTarget.value);
+      setError(fieldName, error);
+    }
+  };
+
+  const setError = (fieldName: string, error: string) => {
+    if (error) {
+      setFieldErrors({ ...fieldErrors, [fieldName]: error });
+      setFieldStates({ ...fieldStates, [fieldName]: 'error' });
+    } else {
+      const newErrors = { ...fieldErrors };
+      delete newErrors[fieldName];
+      setFieldErrors(newErrors);
+      setFieldStates({ ...fieldStates, [fieldName]: 'success' });
+    }
+  };
+
+  const onSubmit = () => {
+    for (const key in fieldValidators) {
+      const error = fieldValidators[key](fieldValues[key]);
+
+      if (error) {
+        setFieldErrors({ ...fieldErrors, [key]: error });
+      } else {
+        const newErrors = { ...fieldErrors };
+        delete newErrors[key];
+        setFieldErrors(newErrors);
+      }
+    }
+
+    setIsSubmitting(true);
+  };
+
+  return { fieldValues, fieldErrors, fieldStates, isFormValid, onChange, setFieldValues, onSubmit };
+};

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -87,10 +87,7 @@ export const useForm = (initForm: Omit<Omit<IFormState, 'errorMessage'>, 'state'
   }, [form]);
 
   // callback (on change of input)
-  const onChange = (event: React.FormEvent<HTMLInputElement> | React.FormEvent<HTMLTextAreaElement>) => {
-    const fieldName = event.currentTarget.name;
-    const fieldValue = event.currentTarget.value;
-
+  const onChange = (fieldName: any, fieldValue: any) => {
     const newFieldState = { ...form[fieldName], value: fieldValue };
     const validatedFieldState = validate(newFieldState);
     setForm({ ...form, [fieldName]: validatedFieldState });

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { copyAndSetValues } from '../utils/utils';
 
 interface IFieldValues {
   [key: string]: string;
@@ -57,10 +58,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   // inpur validation functions
   const [fieldValidators, setFieldValidators] = useState<IFieldValidators>(validators);
 
-  const initFieldStates = { ...initValues };
-  Object.keys(initFieldStates).forEach((key) => {
-    initFieldStates[key] = 'default';
-  });
+  const initFieldStates = copyAndSetValues(initValues, 'default');
   // input states - 'default' | 'success' | 'error'
   const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
 

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -18,7 +18,7 @@ interface IField {
   validators?: IValidator[];
 }
 
-export interface IForm {
+export interface IFields {
   [key: string]: IField;
 }
 
@@ -56,13 +56,13 @@ export interface IForm {
  *        -> validator    -- validation function
  *        -> errorMessage -- error message that should be set in a case of an error
  */
-export const useForm = (initForm: Omit<Omit<IForm, 'errorMessage'>, 'state'>, callback: Function) => {
+export const useForm = (initForm: Omit<Omit<IFields, 'errorMessage'>, 'state'>, callback: Function) => {
   const defaultForm = { ...initForm };
   for (const key in defaultForm) {
     if (!defaultForm[key].value) defaultForm[key].value = '';
     defaultForm[key].state = 'default';
   }
-  const [form, setForm] = useState<IForm>(defaultForm);
+  const [fields, setFields] = useState<IFields>(defaultForm);
 
   // is submit button disabled?
   const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(true);
@@ -72,35 +72,35 @@ export const useForm = (initForm: Omit<Omit<IForm, 'errorMessage'>, 'state'>, ca
 
   // are all validated inputs valid?
   const isFormValid = useCallback(() => {
-    for (const key in form) {
-      if (form[key].errorMessages?.length) return false;
+    for (const key in fields) {
+      if (fields[key].errorMessages?.length) return false;
     }
 
     return true;
-  }, [form]);
+  }, [fields]);
 
   // are all required inputs filled?
   const areRequiredFilled = useCallback(() => {
-    for (const key in form) {
-      if (form[key].isRequired && !form[key].value) {
+    for (const key in fields) {
+      if (fields[key].isRequired && !fields[key].value) {
         return false;
       }
     }
 
     return true;
-  }, [form]);
+  }, [fields]);
 
   // callback (on change of an input)
   const onChange = (fieldName: any, fieldValue: any) => {
     // also delete old error messages, new checks are going to be done
     const newFieldState = {
-      ...form[fieldName],
+      ...fields[fieldName],
       value: fieldValue,
       errorMessages: [],
       state: 'default' as TextInputProps['validated'],
     };
     validate(newFieldState);
-    setForm({ ...form, [fieldName]: newFieldState });
+    setFields({ ...fields, [fieldName]: newFieldState });
 
     setHasChanged(true);
   };
@@ -158,26 +158,26 @@ export const useForm = (initForm: Omit<Omit<IForm, 'errorMessage'>, 'state'>, ca
     });
 
     // reset state to 'default' (valid inputs wont be highlighted)
-    const formCopy = { ...form };
+    const formCopy = { ...fields };
     for (const key in formCopy) {
       formCopy[key].state = 'default';
     }
-    setForm(formCopy);
+    setFields(formCopy);
     setHasChanged(false);
   };
 
   // set all input field to values (used for edit form)
   const applyValues = useCallback(
     (fieldValues: IFieldValues) => {
-      const newForm = { ...form };
+      const newForm = { ...fields };
       for (const key in fieldValues) {
         newForm[key].value = fieldValues[key];
         newForm[key].state = 'default';
       }
 
-      setForm(newForm);
+      setFields(newForm);
     },
-    [form]
+    [fields]
   );
 
   // on change of a input, check whether submit button should be disabled
@@ -187,7 +187,7 @@ export const useForm = (initForm: Omit<Omit<IForm, 'errorMessage'>, 'state'>, ca
     } else {
       setIsSubmitDisabled(true);
     }
-  }, [form, hasChanged, isFormValid, areRequiredFilled]);
+  }, [fields, hasChanged, isFormValid, areRequiredFilled]);
 
-  return { form, applyValues, onChange, onSubmit, isSubmitDisabled };
+  return { fields, applyValues, onChange, onSubmit, isSubmitDisabled };
 };

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -93,11 +93,14 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
 
   // callback (on change of an input)
   const onChange = (fieldName: string, fieldValue: any) => {
-    // also delete old error messages, new checks are going to be done
+    // also delete old error messages, new checks are going to be done(
+
+    // trim just strings
+    const editedFieldValue = typeof fieldValue == 'string' ? fieldValue.trim() : fieldValue;
 
     const newField = {
       ...fields[fieldName],
-      value: fieldValue ? fieldValue : '',
+      value: editedFieldValue,
       errorMessages: [],
       state: 'default' as TextInputProps['validated'],
     };
@@ -203,7 +206,7 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
     } else {
       setIsSubmitDisabled(true);
     }
-  }, [fields, hasChanged, isFormValid, areRequiredFilled]);
+  }, [fields, hasChanged]);
 
   return { fields, reinitialize, onChange, onSubmit, isSubmitDisabled };
 };

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -91,26 +91,6 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
   // important for edit page (do not submit until any new content)
   const [hasChanged, setHasChanged] = useState<boolean>(false);
 
-  // are all validated inputs valid?
-  const isFormValid = useCallback(() => {
-    for (const key in fields) {
-      if (fields[key].errorMessages?.length) return false;
-    }
-
-    return true;
-  }, [fields]);
-
-  // are all required inputs filled?
-  const areRequiredFilled = useCallback(() => {
-    for (const key in fields) {
-      if (fields[key].isRequired && !fields[key].value) {
-        return false;
-      }
-    }
-
-    return true;
-  }, [fields]);
-
   // callback (on change of an input)
   const onChange = (fieldName: string, fieldValue: any) => {
     // also delete old error messages, new checks are going to be done
@@ -198,6 +178,26 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
 
   // on change of a input, check whether submit button should be disabled
   useEffect(() => {
+    // are all validated inputs valid?
+    const isFormValid = () => {
+      for (const key in fields) {
+        if (fields[key].errorMessages?.length) return false;
+      }
+
+      return true;
+    };
+
+    // are all required inputs filled?
+    const areRequiredFilled = () => {
+      for (const key in fields) {
+        if (fields[key].isRequired && !fields[key].value) {
+          return false;
+        }
+      }
+
+      return true;
+    };
+
     if (isFormValid() && areRequiredFilled() && hasChanged) {
       setIsSubmitDisabled(false);
     } else {

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -12,20 +12,38 @@ interface IFieldValidators {
   [key: string]: Function;
 }
 
+/**
+ * Hook to manage input values, validation and states of a form. All validation is done on change of input.
+ * See also {@link ProjectCreateEditPage}
+ *
+ * @param initValues - Values to initialize inputs with
+ * @param validators - Functions to validate inputs with
+ * @param callback - Function to call when submitting user input data
+ *
+ * Both initValues and validators are objects whose keys are equal to ids of input elements.
+ */
 export const useForm = (initValues: IFieldValues, validators: IFieldValidators, callback: Function) => {
+  // are all form inputs valid?
   const [isFormValid, setIsFormValid] = useState<boolean>(false);
+  // has user made any changes to the newly loaded form?
+  // at least one change must be to in order to submit form
   const [hasChanged, setHasChanged] = useState<boolean>(false);
 
+  // input values
   const [fieldValues, setFieldValues] = useState<IFieldValues>(initValues);
+  // input error messages
   const [fieldErrors, setFieldErrors] = useState<IFieldErros>({});
+  // inpur validation functons
   const [fieldValidators, setFieldValidators] = useState<IFieldValidators>(validators);
 
+  // submitting state
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const initFieldStates = { ...initValues };
   Object.keys(initFieldStates).forEach((key) => {
     initFieldStates[key] = 'default';
   });
+  // input states - 'default' | 'success' | 'error'
   const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
 
   useEffect(() => {
@@ -33,6 +51,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
       setIsFormValid(true);
       if (isSubmitting) {
         callback(fieldValues);
+        // reset state to 'default' (valid inputs wont be highlighted)
         setFieldStates(initFieldStates);
       }
     } else {
@@ -47,6 +66,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
     setFieldValues({ ...fieldValues, [fieldName]: event.currentTarget.value });
     setHasChanged(true);
 
+    // if has any validator
     if (fieldValidators[fieldName]) {
       const error = fieldValidators[fieldName](event.currentTarget.value);
       setError(fieldName, error);
@@ -66,18 +86,6 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   };
 
   const onSubmit = () => {
-    for (const key in fieldValidators) {
-      const error = fieldValidators[key](fieldValues[key]);
-
-      if (error) {
-        setFieldErrors({ ...fieldErrors, [key]: error });
-      } else {
-        const newErrors = { ...fieldErrors };
-        delete newErrors[key];
-        setFieldErrors(newErrors);
-      }
-    }
-
     setIsSubmitting(true);
   };
 

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -46,6 +46,9 @@ interface IValidator {
 export const useForm = (initValues: IFieldValues, validators: IFieldValidators, callback: Function) => {
   // is submit button disabled?
   const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(true);
+  // has any field been changed?
+  // important for edit page (do not submit until any new content)
+  const [hasChanged, setHasChanged] = useState<boolean>(false);
 
   // input values
   const [fieldValues, setFieldValues] = useState<IFieldValues>(initValues);
@@ -62,7 +65,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
 
   useEffect(() => {
-    if (isFormValid() && areRequiredFilled()) {
+    if (isFormValid() && areRequiredFilled() && hasChanged) {
       setIsSubmitDisabled(false);
     } else {
       setIsSubmitDisabled(true);
@@ -89,9 +92,10 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   const onChange = (event: React.FormEvent<HTMLInputElement> | React.FormEvent<HTMLTextAreaElement>) => {
     const fieldName = event.currentTarget.name;
     const fieldValue = event.currentTarget.value;
-    setFieldValues({ ...fieldValues, [fieldName]: fieldValue });
 
+    setFieldValues({ ...fieldValues, [fieldName]: fieldValue });
     validate(fieldName, fieldValue);
+    setHasChanged(true);
   };
 
   // validate field

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -136,7 +136,8 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
     } else {
       setIsSubmitDisabled(true);
     }
-  }, [fieldValues, hasChanged, isFormValid, areRequiredFilled]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fieldValues]);
 
   return { fieldValues, fieldErrors, fieldStates, isSubmitDisabled, onChange, setFieldValues, onSubmit };
 };

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -9,35 +9,50 @@ interface IFieldErrors {
 }
 
 interface IFieldValidators {
-  [key: string]: Function;
+  [key: string]: IValidator;
+}
+
+interface IValidator {
+  isRequired?: boolean;
+  validator?: Function;
 }
 
 /**
- * Hook to manage input values, validation and states of a form. All validation is done on change of input.
+ * Hook to manage input values, validation and states of a form.
+ * All validation is done on change of input.
+ * Submit button is firstly disabled. In order to enable button:
+ *  -> at least one change must be done
+ *  -> all required fields must not be empty
+ *  -> all validated inputs must be valid
+ *
  * See also {@link ProjectCreateEditPage}
  *
  * @param initValues - Values to initialize inputs with
- * @param validators - Functions to validate inputs with
+ * @param validators - Objects consisting of whether is input required and validation function
  * @param callback - Function to call when submitting user input data
  *
- * Both initValues and validators are objects whose keys are equal to ids of input elements.
+ * @returns form states and access functions
+ *  -> fieldValues - values of input fields
+ *  -> fieldErrors - error messages of inout fields
+ *  -> fieldStates - 'default' | 'success' | 'error'
+ *  -> isSubmitDisabled - submit disabled or not
+ *  -> onChange - callback for input fields on change
+ *  -> setFieldValues - set all field values
+ *  -> onSubmit - callback for submit button
+ *
+ * initValues, validators, fieldValues, fieldErrors, fieldStates are objects whose keys are equal to ids of inputs fields.
+ * example: validators.projectUrl.isRequired
  */
 export const useForm = (initValues: IFieldValues, validators: IFieldValidators, callback: Function) => {
-  // are all form inputs valid?
-  const [isFormValid, setIsFormValid] = useState<boolean>(false);
-  // has user made any changes to the newly loaded form?
-  // at least one change must be to in order to submit form
-  const [hasChanged, setHasChanged] = useState<boolean>(false);
+  // is submit button disabled?
+  const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(true);
 
   // input values
   const [fieldValues, setFieldValues] = useState<IFieldValues>(initValues);
   // input error messages
   const [fieldErrors, setFieldErrors] = useState<IFieldErrors>({});
-  // inpur validation functons
+  // inpur validation functions
   const [fieldValidators, setFieldValidators] = useState<IFieldValidators>(validators);
-
-  // submitting state
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const initFieldStates = { ...initValues };
   Object.keys(initFieldStates).forEach((key) => {
@@ -47,41 +62,64 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
 
   useEffect(() => {
-    if (!Object.keys(fieldErrors).length && hasChanged) {
-      setIsFormValid(true);
-      if (isSubmitting) {
-        callback(fieldValues);
-        // reset state to 'default' (valid inputs wont be highlighted)
-        setFieldStates(initFieldStates);
-      }
+    if (isFormValid() && areRequiredFilled()) {
+      setIsSubmitDisabled(false);
     } else {
-      setIsFormValid(false);
+      setIsSubmitDisabled(true);
+    }
+  }, [fieldValues]);
+
+  // are all validated inputs valid?
+  const isFormValid = () => {
+    return !Object.keys(fieldErrors).length;
+  };
+
+  // are all required inputs filled?
+  const areRequiredFilled = () => {
+    for (const key in fieldValidators) {
+      if (fieldValidators[key].isRequired && !fieldValues[key]) {
+        return false;
+      }
     }
 
-    setIsSubmitting(false);
-  }, [fieldErrors, hasChanged]);
+    return true;
+  };
 
+  // callback (on change of input)
   const onChange = (event: React.FormEvent<HTMLInputElement> | React.FormEvent<HTMLTextAreaElement>) => {
     const fieldName = event.currentTarget.name;
     const fieldValue = event.currentTarget.value;
     setFieldValues({ ...fieldValues, [fieldName]: fieldValue });
-    setHasChanged(true);
 
-    // if has any validator
+    validate(fieldName, fieldValue);
+  };
+
+  // validate field
+  const validate = (fieldName: string, fieldValue: string) => {
     if (fieldValidators[fieldName]) {
-      const error = fieldValidators[fieldName](fieldValue);
-      setError(fieldName, fieldValue, error);
+      const isRequired = fieldValidators[fieldName].isRequired;
+      const validator = fieldValidators[fieldName].validator;
+      if (isRequired) {
+        const error = fieldValue ? '' : 'Field must be filled!';
+        setError(fieldName, fieldValue, error);
+      } else if (validator) {
+        const error = validator(fieldValue);
+        setError(fieldName, fieldValue, error);
+      }
     }
   };
 
+  // set error message and state
   const setError = (fieldName: string, fieldValue: string, error: string) => {
     if (error) {
       setFieldErrors({ ...fieldErrors, [fieldName]: error });
       setFieldStates({ ...fieldStates, [fieldName]: 'error' });
     } else {
+      // if no error, delete old error (if any)
       const newErrors = { ...fieldErrors };
       delete newErrors[fieldName];
       setFieldErrors(newErrors);
+      // display success state only if not empty
       if (fieldValue) {
         setFieldStates({ ...fieldStates, [fieldName]: 'success' });
       } else {
@@ -90,24 +128,13 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
     }
   };
 
+  // callback (on submit of form)
   const onSubmit = () => {
-    let errors: IFieldErrors = {};
-
-    // check all validated inputs before submit
-    for (const key in fieldValidators) {
-      const error = fieldValidators[key](fieldValues[key]);
-      if (error) errors[key] = error;
-    }
-
-    setFieldErrors(errors);
-    const fieldStates = { ...errors };
-    Object.keys(fieldStates).forEach((key) => {
-      fieldStates[key] = 'error';
-    });
-    setFieldStates(fieldStates);
-
-    setIsSubmitting(true);
+    callback(fieldValues);
+    // reset state to 'default' (valid inputs wont be highlighted)
+    setFieldStates(initFieldStates);
+    setIsSubmitDisabled(true);
   };
 
-  return { fieldValues, fieldErrors, fieldStates, isFormValid, onChange, setFieldValues, onSubmit };
+  return { fieldValues, fieldErrors, fieldStates, isSubmitDisabled, onChange, setFieldValues, onSubmit };
 };

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { copyAndSetValues } from '../utils/utils';
 
 interface IFieldValues {
@@ -63,12 +63,12 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
 
   // are all validated inputs valid?
-  const isFormValid = () => {
+  const isFormValid = useCallback(() => {
     return !Object.keys(fieldErrors).length;
-  };
+  }, [fieldErrors]);
 
   // are all required inputs filled?
-  const areRequiredFilled = () => {
+  const areRequiredFilled = useCallback(() => {
     for (const key in fieldValidators) {
       if (fieldValidators[key].isRequired && !fieldValues[key]) {
         return false;
@@ -76,7 +76,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
     }
 
     return true;
-  };
+  }, [fieldValidators, fieldValues]);
 
   // callback (on change of input)
   const onChange = (event: React.FormEvent<HTMLInputElement> | React.FormEvent<HTMLTextAreaElement>) => {
@@ -136,8 +136,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
     } else {
       setIsSubmitDisabled(true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fieldValues]);
+  }, [fieldValues, hasChanged, isFormValid, areRequiredFilled]);
 
   return { fieldValues, fieldErrors, fieldStates, isSubmitDisabled, onChange, setFieldValues, onSubmit };
 };

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -62,7 +62,7 @@ export interface IFormState {
 export const useForm = (initForm: Omit<Omit<IFormState, 'errorMessage'>, 'state'>, callback: Function) => {
   const defaultForm = { ...initForm };
   for (const key in defaultForm) {
-    defaultForm[key].value = '';
+    if (!defaultForm[key].value) defaultForm[key].value = '';
     defaultForm[key].state = 'default';
   }
   const [form, setForm] = useState<IFormState>(defaultForm);

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -4,7 +4,7 @@ interface IFieldValues {
   [key: string]: string;
 }
 
-interface IFieldErros {
+interface IFieldErrors {
   [key: string]: string | undefined;
 }
 
@@ -32,7 +32,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   // input values
   const [fieldValues, setFieldValues] = useState<IFieldValues>(initValues);
   // input error messages
-  const [fieldErrors, setFieldErrors] = useState<IFieldErros>({});
+  const [fieldErrors, setFieldErrors] = useState<IFieldErrors>({});
   // inpur validation functons
   const [fieldValidators, setFieldValidators] = useState<IFieldValidators>(validators);
 
@@ -47,6 +47,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
 
   useEffect(() => {
+    console.log(Object.keys(fieldErrors).length);
     if (!Object.keys(fieldErrors).length && hasChanged) {
       setIsFormValid(true);
       if (isSubmitting) {
@@ -59,7 +60,7 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
     }
 
     setIsSubmitting(false);
-  }, [fieldErrors]);
+  }, [fieldErrors, hasChanged]);
 
   const onChange = (event: React.FormEvent<HTMLInputElement> | React.FormEvent<HTMLTextAreaElement>) => {
     const fieldName = event.currentTarget.name;
@@ -86,6 +87,21 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   };
 
   const onSubmit = () => {
+    let errors: IFieldErrors = {};
+
+    // check all validated inputs before submit
+    for (const key in fieldValidators) {
+      const error = fieldValidators[key](fieldValues[key]);
+      if (error) errors[key] = error;
+    }
+
+    setFieldErrors(errors);
+    const fieldStates = { ...errors };
+    Object.keys(fieldStates).forEach((key) => {
+      fieldStates[key] = 'error';
+    });
+    setFieldStates(fieldStates);
+
     setIsSubmitting(true);
   };
 

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -47,7 +47,6 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
 
   useEffect(() => {
-    console.log(Object.keys(fieldErrors).length);
     if (!Object.keys(fieldErrors).length && hasChanged) {
       setIsFormValid(true);
       if (isSubmitting) {
@@ -64,17 +63,18 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
 
   const onChange = (event: React.FormEvent<HTMLInputElement> | React.FormEvent<HTMLTextAreaElement>) => {
     const fieldName = event.currentTarget.name;
-    setFieldValues({ ...fieldValues, [fieldName]: event.currentTarget.value });
+    const fieldValue = event.currentTarget.value;
+    setFieldValues({ ...fieldValues, [fieldName]: fieldValue });
     setHasChanged(true);
 
     // if has any validator
     if (fieldValidators[fieldName]) {
-      const error = fieldValidators[fieldName](event.currentTarget.value);
-      setError(fieldName, error);
+      const error = fieldValidators[fieldName](fieldValue);
+      setError(fieldName, fieldValue, error);
     }
   };
 
-  const setError = (fieldName: string, error: string) => {
+  const setError = (fieldName: string, fieldValue: string, error: string) => {
     if (error) {
       setFieldErrors({ ...fieldErrors, [fieldName]: error });
       setFieldStates({ ...fieldStates, [fieldName]: 'error' });
@@ -82,7 +82,11 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
       const newErrors = { ...fieldErrors };
       delete newErrors[fieldName];
       setFieldErrors(newErrors);
-      setFieldStates({ ...fieldStates, [fieldName]: 'success' });
+      if (fieldValue) {
+        setFieldStates({ ...fieldStates, [fieldName]: 'success' });
+      } else {
+        setFieldStates({ ...fieldStates, [fieldName]: 'default' });
+      }
     }
   };
 

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -56,19 +56,11 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
   // input error messages
   const [fieldErrors, setFieldErrors] = useState<IFieldErrors>({});
   // inpur validation functions
-  const [fieldValidators, setFieldValidators] = useState<IFieldValidators>(validators);
+  const [fieldValidators] = useState<IFieldValidators>(validators);
 
   const initFieldStates = copyAndSetValues(initValues, 'default');
   // input states - 'default' | 'success' | 'error'
   const [fieldStates, setFieldStates] = useState<any>(initFieldStates);
-
-  useEffect(() => {
-    if (isFormValid() && areRequiredFilled() && hasChanged) {
-      setIsSubmitDisabled(false);
-    } else {
-      setIsSubmitDisabled(true);
-    }
-  }, [fieldValues]);
 
   // are all validated inputs valid?
   const isFormValid = () => {
@@ -137,6 +129,14 @@ export const useForm = (initValues: IFieldValues, validators: IFieldValidators, 
     setFieldStates(initFieldStates);
     setIsSubmitDisabled(true);
   };
+
+  useEffect(() => {
+    if (isFormValid() && areRequiredFilled() && hasChanged) {
+      setIsSubmitDisabled(false);
+    } else {
+      setIsSubmitDisabled(true);
+    }
+  }, [fieldValues, hasChanged, isFormValid, areRequiredFilled]);
 
   return { fieldValues, fieldErrors, fieldStates, isSubmitDisabled, onChange, setFieldValues, onSubmit };
 };

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -5,7 +5,7 @@ export interface IFieldValues {
 }
 
 interface IValidator {
-  check: Function;
+  validator: Function;
   errorMessage: string;
 }
 
@@ -56,7 +56,7 @@ export interface IFormState {
  *    -> validation:    -- means of validation
  *      -> isRequired   -- is field required?
  *      -> validators:  -- validation functions and their error messages
- *        -> check        -- validation function
+ *        -> validator    -- validation function
  *        -> errorMessage -- error message that should be set in a case of an error
  */
 export const useForm = (initForm: Omit<Omit<IFormState, 'errorMessage'>, 'state'>, callback: Function) => {
@@ -114,7 +114,7 @@ export const useForm = (initForm: Omit<Omit<IFormState, 'errorMessage'>, 'state'
     }
     if (validation?.validators) {
       for (const validator of validation.validators) {
-        const error = validator.check(fieldState.value) ? '' : validator.errorMessage;
+        const error = validator.validator(fieldState.value) ? '' : validator.errorMessage;
         addError(fieldState, error);
       }
       setState(fieldState);

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -109,14 +109,16 @@ export const useForm = (initFields: Omit<Omit<IFields, 'errorMessages'>, 'state'
   // validate field state and change error messages / state
   const validate = (field: IField) => {
     if (field.isRequired) {
-      const error = field.value?.trim() ? '' : 'Field must be filled.';
-      addError(field, error);
+      if (!field.value?.trim()) {
+        addError(field, 'Field must be filled.');
+      }
       setState(field);
     }
     if (field.validators) {
       for (const validator of field.validators) {
-        const error = validator.validator(field.value) ? '' : validator.errorMessage;
-        addError(field, error);
+        if (!validator.validator(field.value)) {
+          addError(field, validator.errorMessage);
+        }
       }
       setState(field);
     }

--- a/src/utils/formValidationHelpers.ts
+++ b/src/utils/formValidationHelpers.ts
@@ -1,3 +1,5 @@
+// all validation functions should return boolean and accept empty string as valid
+
 // url regex taken from:
 // https://uibakery.io/regex-library/url
 // eslint-disable-next-line
@@ -9,9 +11,36 @@ const urlRegex = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-
  * Just checks valid URL format. Accepts empty URL.
  *
  * @param url - URL string
- * @returns empty string if valid, error message otherwise
+ * @returns true if valid, false otherwise
  */
-export const validateUrl = (url: string) => {
-  if (url && !urlRegex.test(url)) return 'Invalid URL format';
-  return '';
+export const validateUrl = (url: string): boolean => {
+  return !url || urlRegex.test(url);
+};
+
+/**
+ * Creator of a min length validation function.
+ *
+ * Returned function accepts empty string.
+ *
+ * @param min - Minimal length of a string returned function will validate
+ * @returns function validating minimal length
+ */
+export const minLength = (min: number): Function => {
+  return (string: string): boolean => {
+    return !string || string.length >= min;
+  };
+};
+
+/**
+ * Creator of a max length validation function.
+ *
+ * Returned function accepts empty string.
+ *
+ * @param max - Maximal length of a string returned function will validate
+ * @returns function validating maximal length
+ */
+export const maxLength = (max: number): Function => {
+  return (string: string): boolean => {
+    return !string || string.length <= max;
+  };
 };

--- a/src/utils/formValidationHelpers.ts
+++ b/src/utils/formValidationHelpers.ts
@@ -1,5 +1,6 @@
 // url regex taken from:
 // https://uibakery.io/regex-library/url
+// eslint-disable-next-line
 const urlRegex = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
 
 /**

--- a/src/utils/formValidationHelpers.ts
+++ b/src/utils/formValidationHelpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Project name validation function.
+ *
+ * @param name - Project name
+ * @returns empty string if valid, error message otherwise
+ */
+
+export const validateProjectName = (name: String) => {
+  if (!name) return 'Name is required';
+  return '';
+};
+
+/**
+ * URL validation function.
+ *
+ * Just checks valid URL format. Accepts empty URL.
+ *
+ * @param url - URL string
+ * @returns empty string if valid, error message otherwise
+ */
+
+// url regex taken from:
+// https://uibakery.io/regex-library/url
+
+const urlRegex = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
+
+export const validateUrl = (url: string) => {
+  if (url && !urlRegex.test(url)) return 'Invalid URL';
+  return '';
+};

--- a/src/utils/formValidationHelpers.ts
+++ b/src/utils/formValidationHelpers.ts
@@ -1,14 +1,6 @@
-/**
- * Project name validation function.
- *
- * @param name - Project name
- * @returns empty string if valid, error message otherwise
- */
-
-export const validateProjectName = (name: String) => {
-  if (!name) return 'Name is required';
-  return '';
-};
+// url regex taken from:
+// https://uibakery.io/regex-library/url
+const urlRegex = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
 
 /**
  * URL validation function.
@@ -18,13 +10,7 @@ export const validateProjectName = (name: String) => {
  * @param url - URL string
  * @returns empty string if valid, error message otherwise
  */
-
-// url regex taken from:
-// https://uibakery.io/regex-library/url
-
-const urlRegex = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
-
 export const validateUrl = (url: string) => {
-  if (url && !urlRegex.test(url)) return 'Invalid URL';
+  if (url && !urlRegex.test(url)) return 'Invalid URL format';
   return '';
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,19 +19,3 @@ export const createDateTime = ({ date, includeDate = true, includeTime = true }:
     ...(includeDate && { dateStyle: 'medium' }),
     ...(includeTime && { timeStyle: 'medium' }),
   }).format(typeof date === 'string' ? new Date(date) : date);
-
-/**
- * Copies a object, sets all keys to same value and returns it.
- *
- * @param originalObj - Object to copy.
- * @param value - Value to set all keys of a copy to.
- * @returns copied object with keys set to same value
- */
-export const copyAndSetValues = (originalObj: any, value: any) => {
-  const copiedObj = { ...originalObj };
-  Object.keys(copiedObj).forEach((key) => {
-    copiedObj[key] = value;
-  });
-
-  return copiedObj;
-};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,3 +19,19 @@ export const createDateTime = ({ date, includeDate = true, includeTime = true }:
     ...(includeDate && { dateStyle: 'medium' }),
     ...(includeTime && { timeStyle: 'medium' }),
   }).format(typeof date === 'string' ? new Date(date) : date);
+
+/**
+ * Copies a object, sets all keys to same value and returns it.
+ *
+ * @param originalObj - Object to copy.
+ * @param value - Value to set all keys of a copy to.
+ * @returns copied object with keys set to same value
+ */
+export const copyAndSetValues = (originalObj: any, value: any) => {
+  const copiedObj = { ...originalObj };
+  Object.keys(copiedObj).forEach((key) => {
+    copiedObj[key] = value;
+  });
+
+  return copiedObj;
+};


### PR DESCRIPTION
Backend errors are still displayed on form-level.
Validation backend REST API endpoints needed.
Also would be nice if error server reponse included more info (for example input field id).