### PR TITLE
[NCL-7275] Use import sort plugin for Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,15 @@
 {
   "singleQuote": true,
   "trailingComma": "es5",
-  "printWidth": 130
+  "printWidth": 130,
+  "importOrder": [
+    "^pnc",
+    "^/?(((.*)/)*)containers/(.*)$",
+    "^/?(((.*)/)*)components/(.*)$",
+    "^/?(((.*)/)*)services/(.*)$",
+    "^/?(((.*)/)*)utils/(.*)$",
+    "^[./]"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@trivago/prettier-plugin-sort-imports": "^3.3.0",
         "@types/react-test-renderer": "^17.0.1",
         "axios-mock-adapter": "^1.20.0",
         "husky": "^7.0.4",
@@ -3193,6 +3194,132 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.3.0.tgz",
+      "integrity": "sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "7.17.8",
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "7.17.8",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "prettier": "2.x"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/core": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.8",
+        "@babel/parser": "^7.17.8",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/parser": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@trysound/sax": {
@@ -8657,6 +8784,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "node_modules/jest": {
       "version": "27.5.1",
@@ -22130,6 +22263,103 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
+    "@trivago/prettier-plugin-sort-imports": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.3.0.tgz",
+      "integrity": "sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "7.17.8",
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "7.17.8",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "4.17.21"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.17.8",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+          "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+          "dev": true,
+          "requires": {
+            "@ampproject/remapping": "^2.1.0",
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.7",
+            "@babel/helper-compilation-targets": "^7.17.7",
+            "@babel/helper-module-transforms": "^7.17.7",
+            "@babel/helpers": "^7.17.8",
+            "@babel/parser": "^7.17.8",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.3",
+            "@babel/types": "^7.17.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.2",
+            "json5": "^2.1.2",
+            "semver": "^6.3.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.17.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.17.8",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+          "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.3",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.17.3",
+            "@babel/types": "^7.17.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+          "dev": true
+        }
+      }
+    },
     "@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -26149,6 +26379,12 @@
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
       }
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "jest": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@types/react-test-renderer": "^17.0.1",
     "axios-mock-adapter": "^1.20.0",
     "husky": "^7.0.4",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
+
 import App from './App';
 
 test('renders learn react link', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import logo from './logo.svg';
+
 import './App.css';
+import logo from './logo.svg';
 
 function App() {
   return (

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -1,34 +1,37 @@
-import React, { useState } from 'react';
-import '@patternfly/react-core/dist/styles/base.css';
 import {
-  Nav,
-  NavList,
-  NavItem,
-  NavExpandable,
-  Page,
   Button,
   ButtonVariant,
   Dropdown,
   DropdownItem,
   DropdownToggle,
+  Flex,
+  FlexItem,
+  Nav,
+  NavExpandable,
+  NavItem,
+  NavList,
+  Page,
+  PageHeader,
   PageHeaderTools,
   PageHeaderToolsGroup,
   PageHeaderToolsItem,
-  PageHeader,
   /*Breadcrumb,
-  BreadcrumbItem,*/
+BreadcrumbItem,*/
   PageSidebar,
-  Flex,
-  FlexItem,
 } from '@patternfly/react-core';
+import '@patternfly/react-core/dist/styles/base.css';
 import { BellIcon, CaretDownIcon, CogIcon, OutlinedQuestionCircleIcon, UserIcon } from '@patternfly/react-icons';
+import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import pncLogoText from './pnc-logo-text.svg';
+
 import { AboutModalPage } from './components/AboutModalPage/AboutModalPage';
+import { ProtectedComponent } from './components/ProtectedContent/ProtectedComponent';
+
 import * as WebConfigAPI from './services/WebConfigService';
 import { AUTH_ROLE, keycloakService } from './services/keycloakService';
+
 import styles from './AppLayout.module.css';
-import { ProtectedComponent } from './components/ProtectedContent/ProtectedComponent';
+import pncLogoText from './pnc-logo-text.svg';
 
 interface IAppLayoutProps {}
 

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,28 +1,25 @@
 import { Route, Routes } from 'react-router-dom';
 
-// homepage
-import { DashboardPage } from './components/DashboardPage/DashboardPage';
-
-// entity pages
+import { AdministrationPage } from './components/AdministrationPage/AdministrationPage';
 import { ArtifactsPage } from './components/ArtifactsPage/ArtifactsPage';
 import { BuildConfigsPage } from './components/BuildConfigsPage/BuildConfigsPage';
 import { BuildsPage } from './components/BuildsPage/BuildsPage';
+import { DashboardPage } from './components/DashboardPage/DashboardPage';
+import { DemoPage } from './components/DemoPage/DemoPage';
+import { ErrorPage } from './components/ErrorPage/ErrorPage';
 import { GroupBuildsPage } from './components/GroupBuildsPage/GroupBuildsPage';
 import { GroupConfigsPage } from './components/GroupConfigsPage/GroupConfigsPage';
 import { ProductsPage } from './components/ProductsPage/ProductsPage';
-import { ProjectsPage } from './components/ProjectsPage/ProjectsPage';
 import { ProjectCreateEditPage } from './components/ProjectCreateEditPage/ProjectCreateEditPage';
-import { ScmRepositoriesPage } from './components/ScmRepositoriesPage/ScmRepositoriesPage';
 import { ProjectDetailPage } from './components/ProjectDetailPage/ProjectDetailPage';
-
-// special pages
-import { DemoPage } from './components/DemoPage/DemoPage';
-import { VariablesPage } from './components/VariablesPage/VariablesPage';
-import { AdministrationPage } from './components/AdministrationPage/AdministrationPage';
-import { AUTH_ROLE } from './services/keycloakService';
-import { ErrorPage } from './components/ErrorPage/ErrorPage';
-import { PageTitles } from './utils/PageTitles';
+import { ProjectsPage } from './components/ProjectsPage/ProjectsPage';
 import { ProtectedRoute } from './components/ProtectedContent/ProtectedRoute';
+import { ScmRepositoriesPage } from './components/ScmRepositoriesPage/ScmRepositoriesPage';
+import { VariablesPage } from './components/VariablesPage/VariablesPage';
+
+import { AUTH_ROLE } from './services/keycloakService';
+
+import { PageTitles } from './utils/PageTitles';
 
 export const AppRoutes = () => (
   <Routes>

--- a/src/__tests__/AppLayout.test.tsx
+++ b/src/__tests__/AppLayout.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
-import { AppLayout } from '../AppLayout';
 import { MemoryRouter } from 'react-router-dom';
+
+import { AppLayout } from '../AppLayout';
 
 jest.mock('../services/keycloakService');
 

--- a/src/components/AboutModalPage/AboutModalPage.tsx
+++ b/src/components/AboutModalPage/AboutModalPage.tsx
@@ -1,4 +1,5 @@
 import { AboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';
+
 import pncLogoText from '../../pnc-logo-text.svg';
 import { EmptyStateSymbol } from '../EmptyStates/EmptyStateSymbol';
 

--- a/src/components/AboutModalPage/__tests__/AboutModalPage.test.tsx
+++ b/src/components/AboutModalPage/__tests__/AboutModalPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { AboutModalPage } from '../AboutModalPage';
 
 test('renders AdministrationPage', () => {

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -1,13 +1,13 @@
 import { Button } from '@patternfly/react-core';
 import {
-  TrashIcon,
-  PencilAltIcon,
-  FileIcon,
   CopyIcon,
-  TagIcon,
   ExternalLinkAltIcon,
-  LockIcon,
+  FileIcon,
   FlagIcon,
+  LockIcon,
+  PencilAltIcon,
+  TagIcon,
+  TrashIcon,
 } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/components/ActionButton/__tests__/ActionButton.test.tsx
+++ b/src/components/ActionButton/__tests__/ActionButton.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+
 import { ActionButton } from '../ActionButton';
 
 test('renders ActionButton', () => {

--- a/src/components/AdministrationPage/AdministrationPage.tsx
+++ b/src/components/AdministrationPage/AdministrationPage.tsx
@@ -1,4 +1,3 @@
-import { CSSProperties, useCallback, useState } from 'react';
 import {
   Button,
   Card,
@@ -13,13 +12,17 @@ import {
   TextArea,
   TextInput,
 } from '@patternfly/react-core';
-import { PageLayout } from './../PageLayout/PageLayout';
-import { useTitle } from '../../containers/useTitle';
-import { AttributesItems } from '../AttributesItems/AttributesItems';
-import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';
-import { buildService } from '../../services/buildService';
+import { CSSProperties, useCallback, useState } from 'react';
+
 import { DataContainer } from '../../containers/DataContainer/DataContainer';
+import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';
 import { useInterval } from '../../containers/useInterval';
+import { useTitle } from '../../containers/useTitle';
+
+import { buildService } from '../../services/buildService';
+
+import { AttributesItems } from '../AttributesItems/AttributesItems';
+import { PageLayout } from './../PageLayout/PageLayout';
 
 const REFRESH_INTERVAL_SECONDS = 90;
 

--- a/src/components/AdministrationPage/__tests__/AdministrationPage.test.tsx
+++ b/src/components/AdministrationPage/__tests__/AdministrationPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { AdministrationPage } from '../AdministrationPage';
 
 jest.mock('../../../services/buildService');

--- a/src/components/ArtifactsPage/ArtifactsPage.tsx
+++ b/src/components/ArtifactsPage/ArtifactsPage.tsx
@@ -1,5 +1,7 @@
-import { Divider, PageSection, PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
+import { Divider, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
+
 import { useTitle } from '../../containers/useTitle';
+
 import { PageTitles } from '../../utils/PageTitles';
 
 export const ArtifactsPage = () => {

--- a/src/components/ArtifactsPage/__tests__/ArtifactsPage.test.tsx
+++ b/src/components/ArtifactsPage/__tests__/ArtifactsPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { ArtifactsPage } from '../ArtifactsPage';
 
 test('renders ArtifactsPage', () => {

--- a/src/components/AttributesItems/__tests__/AttributesItems.test.tsx
+++ b/src/components/AttributesItems/__tests__/AttributesItems.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { AttributesItems } from '../AttributesItems';
 
 test('renders AttributesItems', () => {

--- a/src/components/BuildConfigsPage/BuildConfigsPage.tsx
+++ b/src/components/BuildConfigsPage/BuildConfigsPage.tsx
@@ -1,6 +1,8 @@
-import { Divider, PageSection, PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
-import { PageTitles } from '../../utils/PageTitles';
+import { Divider, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
+
 import { useTitle } from '../../containers/useTitle';
+
+import { PageTitles } from '../../utils/PageTitles';
 
 export const BuildConfigsPage = () => {
   useTitle(PageTitles.buildConfig);

--- a/src/components/BuildConfigsPage/__tests__/BuildConfigsPage.test.tsx
+++ b/src/components/BuildConfigsPage/__tests__/BuildConfigsPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { BuildConfigsPage } from '../BuildConfigsPage';
 
 test('renders BuildConfigsPage', () => {

--- a/src/components/BuildMetrics/BuildMetrics.tsx
+++ b/src/components/BuildMetrics/BuildMetrics.tsx
@@ -1,14 +1,18 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
-import Chart, { ChartConfiguration } from 'chart.js/auto';
-import { calculateBuildName } from '../BuildName/BuildName';
-import { Select, SelectOption, Popover, SelectVariant } from '@patternfly/react-core';
+import { Popover, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
-import { Build } from 'pnc-api-types-ts';
-import { buildService } from '../../services/buildService';
-import styles from './BuildMetrics.module.css';
-import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';
-import { DataContainer } from '../../containers/DataContainer/DataContainer';
 import { AxiosResponse } from 'axios';
+import Chart, { ChartConfiguration } from 'chart.js/auto';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Build } from 'pnc-api-types-ts';
+
+import { DataContainer } from '../../containers/DataContainer/DataContainer';
+import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';
+
+import { buildService } from '../../services/buildService';
+
+import { calculateBuildName } from '../BuildName/BuildName';
+import styles from './BuildMetrics.module.css';
 
 interface IBuildMetricsProps {
   builds: Array<Build>;

--- a/src/components/BuildName/BuildName.tsx
+++ b/src/components/BuildName/BuildName.tsx
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
+
 import { Build, GroupBuild } from 'pnc-api-types-ts';
 
-import { isGroupBuild, isBuild } from '../../utils/entityRecognition';
+import { isBuild, isGroupBuild } from '../../utils/entityRecognition';
 
 export const calculateBuildName = (build: Build | GroupBuild) => {
   if (isGroupBuild(build)) {

--- a/src/components/BuildName/__tests__/BuildName.test.tsx
+++ b/src/components/BuildName/__tests__/BuildName.test.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react';
-import { Build, GroupBuild } from 'pnc-api-types-ts';
 import { MemoryRouter } from 'react-router-dom';
-import { BuildName } from '../BuildName';
 
+import { Build, GroupBuild } from 'pnc-api-types-ts';
+
+import { BuildName } from '../BuildName';
 import mockBuildData from './data/mock-build-data.json';
 
 describe('display BuildName component', () => {

--- a/src/components/BuildStartButton/BuildStartButton.tsx
+++ b/src/components/BuildStartButton/BuildStartButton.tsx
@@ -10,9 +10,11 @@ import {
   Popover,
   Radio,
 } from '@patternfly/react-core';
-import { InfoCircleIcon, WarningTriangleIcon, BuildIcon } from '@patternfly/react-icons';
-import { BuildConfiguration, GroupConfiguration } from 'pnc-api-types-ts';
+import { BuildIcon, InfoCircleIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { useState } from 'react';
+
+import { BuildConfiguration, GroupConfiguration } from 'pnc-api-types-ts';
+
 import styles from './BuildStartButton.module.css';
 
 interface IBuildStartButtonProp {

--- a/src/components/BuildStatus/BuildStatus.tsx
+++ b/src/components/BuildStatus/BuildStatus.tsx
@@ -1,11 +1,11 @@
 import { Build, GroupBuild } from 'pnc-api-types-ts';
 
-import './BuildStatus.css';
+import { isBuild } from '../../utils/entityRecognition';
+import { createDateTime } from '../../utils/utils';
 
 import { BuildName } from '../BuildName/BuildName';
 import { BuildStatusIcon } from '../BuildStatusIcon/BuildStatusIcon';
-import { isBuild } from '../../utils/entityRecognition';
-import { createDateTime } from '../../utils/utils';
+import './BuildStatus.css';
 
 interface IBuildStatus {
   build: Build | GroupBuild;

--- a/src/components/BuildStatus/__tests__/BuildStatus.test.tsx
+++ b/src/components/BuildStatus/__tests__/BuildStatus.test.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react';
-import { Build, GroupBuild } from 'pnc-api-types-ts';
 import { MemoryRouter } from 'react-router-dom';
-import { BuildStatus } from '../BuildStatus';
 
+import { Build, GroupBuild } from 'pnc-api-types-ts';
+
+import { BuildStatus } from '../BuildStatus';
 import mockBuildData from './data/mock-build-data.json';
 
 describe('display BuildStatus component', () => {

--- a/src/components/BuildStatusIcon/BuildStatusIcon.tsx
+++ b/src/components/BuildStatusIcon/BuildStatusIcon.tsx
@@ -1,17 +1,18 @@
 import { Tooltip } from '@patternfly/react-core';
-import { OutlinedClockIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { ExclamationTriangleIcon, OutlinedClockIcon } from '@patternfly/react-icons';
+
 import { Build, GroupBuild } from 'pnc-api-types-ts';
 
-import styles from './BuildStatusIcon.module.css';
+import { isBuild } from '../../utils/entityRecognition';
 
+import styles from './BuildStatusIcon.module.css';
 import iconBlue from './icons/blue.svg';
 import iconError from './icons/error.svg';
 import iconGreen from './icons/green.svg';
 import iconGrey from './icons/grey.svg';
+import iconNoBuilds from './icons/no-builds.svg';
 import iconOrange from './icons/orange.svg';
 import iconRed from './icons/red.svg';
-import iconNoBuilds from './icons/no-builds.svg';
-import { isBuild } from '../../utils/entityRecognition';
 
 const iconData: { [buildStatus: string]: { tooltip: string; icon: any; className?: string } } = {
   SUCCESS: {

--- a/src/components/BuildStatusIcon/__tests__/BuildStatusIcon.test.tsx
+++ b/src/components/BuildStatusIcon/__tests__/BuildStatusIcon.test.tsx
@@ -1,7 +1,8 @@
 import { render } from '@testing-library/react';
-import { Build, GroupBuild } from 'pnc-api-types-ts';
-import { BuildStatusIcon } from '../BuildStatusIcon';
 
+import { Build, GroupBuild } from 'pnc-api-types-ts';
+
+import { BuildStatusIcon } from '../BuildStatusIcon';
 import mockBuildData from './data/mock-build-data.json';
 
 describe('display BuildStatusIcon component', () => {

--- a/src/components/BuildsPage/BuildsPage.tsx
+++ b/src/components/BuildsPage/BuildsPage.tsx
@@ -1,6 +1,8 @@
-import { Divider, PageSection, PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
-import { PageTitles } from '../../utils/PageTitles';
+import { Divider, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
+
 import { useTitle } from '../../containers/useTitle';
+
+import { PageTitles } from '../../utils/PageTitles';
 
 export const BuildsPage = () => {
   useTitle(PageTitles.builds);

--- a/src/components/BuildsPage/__tests__/BuildsPage.test.tsx
+++ b/src/components/BuildsPage/__tests__/BuildsPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { BuildsPage } from '../BuildsPage';
 
 test('renders BuildsPage', () => {

--- a/src/components/DashboardPage/DashboardPage.tsx
+++ b/src/components/DashboardPage/DashboardPage.tsx
@@ -1,8 +1,11 @@
 import { Grid, GridItem } from '@patternfly/react-core';
-import { PageLayout } from '../PageLayout/PageLayout';
-import { DashboardWidget } from '../DashboardWidget/DashboardWidget';
-import * as WebConfigAPI from '../../services/WebConfigService';
+
 import { useTitle } from '../../containers/useTitle';
+
+import * as WebConfigAPI from '../../services/WebConfigService';
+
+import { DashboardWidget } from '../DashboardWidget/DashboardWidget';
+import { PageLayout } from '../PageLayout/PageLayout';
 
 export const DashboardPage = () => {
   const webConfig = WebConfigAPI.getWebConfig();

--- a/src/components/DashboardPage/__tests__/DashboardPage.test.tsx
+++ b/src/components/DashboardPage/__tests__/DashboardPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { DashboardPage } from '../DashboardPage';
 
 jest.mock('../../../services/WebConfigService');

--- a/src/components/DashboardWidget/__tests__/DashboardWidget.test.tsx
+++ b/src/components/DashboardWidget/__tests__/DashboardWidget.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+
 import { DashboardWidget } from '../DashboardWidget';
 
 test('renders Dashboard Widget', () => {

--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -1,37 +1,41 @@
-import { PageLayout } from '../PageLayout/PageLayout';
-import { useState } from 'react';
 import {
   ActionGroup,
   Button,
   Card,
-  CardTitle,
   CardBody,
+  CardTitle,
   Flex,
+  FlexItem,
   Form,
   FormGroup,
   FormHelperText,
-  FlexItem,
   Select,
   SelectOption,
   SelectVariant,
-  Tooltip,
   TextArea,
   TextInput,
+  Tooltip,
 } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { useState } from 'react';
+
 import { Build } from 'pnc-api-types-ts';
-import { BuildStatus } from '../BuildStatus/BuildStatus';
-import { BuildStatusIcon } from '../BuildStatusIcon/BuildStatusIcon';
+
+import { IFields, useForm } from '../../containers/useForm';
+import { useTitle } from '../../containers/useTitle';
+
+import { maxLength, minLength } from '../../utils/formValidationHelpers';
+
+import { ActionButton } from '../ActionButton/ActionButton';
+import { AttributesItems } from '../AttributesItems/AttributesItems';
 import { BuildMetrics } from '../BuildMetrics/BuildMetrics';
 import { BuildName } from '../BuildName/BuildName';
-import { ProductMilestoneReleaseLabel } from '../ProductMilestoneReleaseLabel/ProductMilestoneReleaseLabel';
 import { BuildStartButton } from '../BuildStartButton/BuildStartButton';
-import { AttributesItems } from '../AttributesItems/AttributesItems';
-import { InfoCircleIcon } from '@patternfly/react-icons';
-import { ActionButton } from '../ActionButton/ActionButton';
+import { BuildStatus } from '../BuildStatus/BuildStatus';
+import { BuildStatusIcon } from '../BuildStatusIcon/BuildStatusIcon';
+import { PageLayout } from '../PageLayout/PageLayout';
+import { ProductMilestoneReleaseLabel } from '../ProductMilestoneReleaseLabel/ProductMilestoneReleaseLabel';
 import mockBuildData from './data/mock-build-data.json';
-import { useTitle } from '../../containers/useTitle';
-import { IFields, useForm } from '../../containers/useForm';
-import { minLength, maxLength } from '../../utils/formValidationHelpers';
 
 const buildRes: Build[] = mockBuildData;
 

--- a/src/components/DemoPage/__tests__/DemoPage.test.tsx
+++ b/src/components/DemoPage/__tests__/DemoPage.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+
 // import { DemoPage } from '../DemoPage';
 
 test('renders DemoPage', () => {

--- a/src/components/EmptyStates/EmptyStateCard.tsx
+++ b/src/components/EmptyStates/EmptyStateCard.tsx
@@ -1,4 +1,5 @@
 import { CubesIcon } from '@patternfly/react-icons';
+
 import { StateCard } from './StateCard';
 
 interface IEmptyStateCard {

--- a/src/components/EmptyStates/ErrorStateCard.tsx
+++ b/src/components/EmptyStates/ErrorStateCard.tsx
@@ -1,4 +1,5 @@
 import { CubesIcon } from '@patternfly/react-icons';
+
 import { StateCard } from './StateCard';
 
 interface IErrorStateCard {

--- a/src/components/EmptyStates/LoadingStateCard.tsx
+++ b/src/components/EmptyStates/LoadingStateCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+
 import { StateCard } from './StateCard';
 
 const Spinner = () => (

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { SystemErrorPage } from '../SystemErrorPage/SystemErrorPage';
 
 export interface ErrorBoundaryProps {

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
+
 import { ErrorBoundary } from '../ErrorBoundary';
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 
 test('renders ErrorBoundary and fire an error', async () => {
   function BuggyCounter() {

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -1,9 +1,11 @@
 import { CubesIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
+
 import { PageTitles } from '../../utils/PageTitles';
+
+import '../../index.css';
 import { StateCard } from '../EmptyStates/StateCard';
 import { PageLayout } from '../PageLayout/PageLayout';
-import '../../index.css';
 
 interface IErrorPageProps {
   pageTitle: string;

--- a/src/components/Filtering/Filtering.tsx
+++ b/src/components/Filtering/Filtering.tsx
@@ -1,9 +1,11 @@
 import { Button, Chip, ChipGroup, InputGroup, Select, SelectOption, SelectVariant, TextInput } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+
 import { constructCustomFilterParam } from '../../utils/customParamHelper';
-import { addQParamItem, IQParamOperators, parseQParamDeep, removeQParamItem } from '../../utils/qParamHelper';
+import { IQParamOperators, addQParamItem, parseQParamDeep, removeQParamItem } from '../../utils/qParamHelper';
 import { getComponentQueryParamValue, updateQueryParamsInURL } from '../../utils/queryParamsHelper';
+
 import styles from './Filtering.module.css';
 
 /**

--- a/src/components/GroupBuildsPage/GroupBuildsPage.tsx
+++ b/src/components/GroupBuildsPage/GroupBuildsPage.tsx
@@ -1,6 +1,8 @@
-import { Divider, PageSection, PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
-import { PageTitles } from '../../utils/PageTitles';
+import { Divider, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
+
 import { useTitle } from '../../containers/useTitle';
+
+import { PageTitles } from '../../utils/PageTitles';
 
 export const GroupBuildsPage = () => {
   useTitle(PageTitles.groupBuilds);

--- a/src/components/GroupBuildsPage/__tests__/GroupBuildsPage.test.tsx
+++ b/src/components/GroupBuildsPage/__tests__/GroupBuildsPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { GroupBuildsPage } from '../GroupBuildsPage';
 
 test('renders GroupBuildsPage', () => {

--- a/src/components/GroupConfigsPage/GroupConfigsPage.tsx
+++ b/src/components/GroupConfigsPage/GroupConfigsPage.tsx
@@ -1,6 +1,8 @@
-import { Divider, PageSection, PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
-import { PageTitles } from '../../utils/PageTitles';
+import { Divider, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
+
 import { useTitle } from '../../containers/useTitle';
+
+import { PageTitles } from '../../utils/PageTitles';
 
 export const GroupConfigsPage = () => {
   useTitle(PageTitles.groupConfig);

--- a/src/components/GroupConfigsPage/__tests__/GroupConfigsPage.test.tsx
+++ b/src/components/GroupConfigsPage/__tests__/GroupConfigsPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { GroupConfigsPage } from '../GroupConfigsPage';
 
 test('renders GroupConfigsPage', () => {

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import { Divider, PageSection, PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
+import { Divider, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
 import React from 'react';
 
 interface IAppLayoutProps {

--- a/src/components/PageLayout/__test__/PageLayout.test.tsx
+++ b/src/components/PageLayout/__test__/PageLayout.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { PageLayout } from '../PageLayout';
 
 test('renders PageLayout', () => {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,7 +1,9 @@
 import { Pagination as PaginationPF, PaginationVariant } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+
 import { getComponentQueryParamsObject, updateQueryParamsInURL } from '../../utils/queryParamsHelper';
+
 import './Pagination.css';
 
 interface IPagination {

--- a/src/components/ProductMilestoneReleaseLabel/ProductMilestoneReleaseLabel.tsx
+++ b/src/components/ProductMilestoneReleaseLabel/ProductMilestoneReleaseLabel.tsx
@@ -1,9 +1,11 @@
 import { Button, Tooltip } from '@patternfly/react-core';
-import { ProductMilestone, ProductRelease } from 'pnc-api-types-ts';
-import { isProductMilestone, isProductRelease } from '../../utils/entityRecognition';
-import styles from './ProductMilestoneReleaseLabel.module.css';
 
+import { ProductMilestone, ProductRelease } from 'pnc-api-types-ts';
+
+import { isProductMilestone, isProductRelease } from '../../utils/entityRecognition';
 import { createDateTime } from '../../utils/utils';
+
+import styles from './ProductMilestoneReleaseLabel.module.css';
 
 interface IProductMilestoneReleaseProp {
   productMilestoneRelease: ProductMilestone | ProductRelease;

--- a/src/components/ProductMilestoneReleaseLabel/__test__/ProductMilestoneReleaseLabel.test.tsx
+++ b/src/components/ProductMilestoneReleaseLabel/__test__/ProductMilestoneReleaseLabel.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+
 import { ProductMilestone, ProductRelease } from 'pnc-api-types-ts';
+
 import { ProductMilestoneReleaseLabel } from '../ProductMilestoneReleaseLabel';
 import productMilestoneMock from './data/product-milestones-mock.json';
 import productReleaseMock from './data/product-releases-mock.json';

--- a/src/components/ProductsPage/ProductsPage.tsx
+++ b/src/components/ProductsPage/ProductsPage.tsx
@@ -1,6 +1,8 @@
-import { Divider, PageSection, PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
-import { PageTitles } from '../../utils/PageTitles';
+import { Divider, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
+
 import { useTitle } from '../../containers/useTitle';
+
+import { PageTitles } from '../../utils/PageTitles';
 
 export const ProductsPage = () => {
   useTitle(PageTitles.products);

--- a/src/components/ProductsPage/__tests__/ProductsPage.test.tsx
+++ b/src/components/ProductsPage/__tests__/ProductsPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { ProductsPage } from '../ProductsPage';
 
 test('renders ProductsPage', () => {

--- a/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
+++ b/src/components/ProjectCreateEditPage/ProjectCreateEditPage.tsx
@@ -13,18 +13,23 @@ import {
   TextArea,
   TextInput,
 } from '@patternfly/react-core';
-import { Project } from 'pnc-api-types-ts';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { PageTitles } from '../../utils/PageTitles';
+
+import { Project } from 'pnc-api-types-ts';
+
 import { DataContainer } from '../../containers/DataContainer/DataContainer';
 import { ServiceContainerCreating } from '../../containers/DataContainer/ServiceContainerCreating';
 import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';
-import { useTitle } from '../../containers/useTitle';
-import { projectService } from '../../services/projectService';
-import { PageLayout } from '../PageLayout/PageLayout';
 import { IFields, useForm } from '../../containers/useForm';
+import { useTitle } from '../../containers/useTitle';
+
+import { projectService } from '../../services/projectService';
+
+import { PageTitles } from '../../utils/PageTitles';
 import { validateUrl } from '../../utils/formValidationHelpers';
+
+import { PageLayout } from '../PageLayout/PageLayout';
 
 interface IProjectCreateEditPageProps {
   editPage?: boolean;

--- a/src/components/ProjectDetailPage/ProjectDetailPage.tsx
+++ b/src/components/ProjectDetailPage/ProjectDetailPage.tsx
@@ -1,15 +1,19 @@
+import { Card, CardBody } from '@patternfly/react-core';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { Card, CardBody } from '@patternfly/react-core';
-import { PageLayout } from './../PageLayout/PageLayout';
-import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';
-import { projectService } from '../../services/projectService';
+
 import { DataContainer } from '../../containers/DataContainer/DataContainer';
-import { SectionHeader } from '../SectionHeader/SectionHeader';
-import { AttributesItems } from '../AttributesItems/AttributesItems';
-import { ActionButton } from '../ActionButton/ActionButton';
+import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';
 import { useTitle } from '../../containers/useTitle';
+
+import { projectService } from '../../services/projectService';
+
 import { PageTitles } from '../../utils/PageTitles';
+
+import { ActionButton } from '../ActionButton/ActionButton';
+import { AttributesItems } from '../AttributesItems/AttributesItems';
+import { SectionHeader } from '../SectionHeader/SectionHeader';
+import { PageLayout } from './../PageLayout/PageLayout';
 
 export const ProjectDetailPage = () => {
   const { projectId } = useParams();

--- a/src/components/ProjectDetailPage/__tests__/ProjectDetailPage.test.tsx
+++ b/src/components/ProjectDetailPage/__tests__/ProjectDetailPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { ProjectDetailPage } from '../ProjectDetailPage';
 import { MemoryRouter } from 'react-router-dom';
+
+import { ProjectDetailPage } from '../ProjectDetailPage';
 
 jest.mock('../../../services/projectService');
 

--- a/src/components/ProjectLink/__tests__/ProjectLink.test.tsx
+++ b/src/components/ProjectLink/__tests__/ProjectLink.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
-import { ProjectLink } from '../ProjectLink';
 import { MemoryRouter } from 'react-router-dom';
+
+import { ProjectLink } from '../ProjectLink';
 
 describe('display ProjectList component', () => {
   test('renders ProjectLink', () => {

--- a/src/components/ProjectsList/ProjectsList.tsx
+++ b/src/components/ProjectsList/ProjectsList.tsx
@@ -1,8 +1,8 @@
 import '@patternfly/react-core/dist/styles/base.css';
-
-import { Table, TableHeader, TableBody, cellWidth } from '@patternfly/react-table';
-import { Project } from 'pnc-api-types-ts';
+import { Table, TableBody, TableHeader, cellWidth } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
+
+import { Project } from 'pnc-api-types-ts';
 
 import { ProjectLink } from '../ProjectLink/ProjectLink';
 import { ProtectedComponent } from '../ProtectedContent/ProtectedComponent';

--- a/src/components/ProjectsList/__tests__/ProjectsList.test.tsx
+++ b/src/components/ProjectsList/__tests__/ProjectsList.test.tsx
@@ -1,6 +1,7 @@
-import { ProjectsList } from '../ProjectsList';
-import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ProjectsList } from '../ProjectsList';
 
 jest.mock('../../../services/projectService');
 jest.mock('../../../services/keycloakService');

--- a/src/components/ProjectsPage/ProjectsPage.tsx
+++ b/src/components/ProjectsPage/ProjectsPage.tsx
@@ -1,17 +1,21 @@
-import { ProjectsList } from './../ProjectsList/ProjectsList';
-import { PageLayout } from './../PageLayout/PageLayout';
+import { Label, ToolbarItem } from '@patternfly/react-core';
+
 import { DataContainer } from '../../containers/DataContainer/DataContainer';
 import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';
-import { projectService } from '../../services/projectService';
-import { Flex, FlexItem, Label, ToolbarItem } from '@patternfly/react-core';
-import { Pagination } from '../Pagination/Pagination';
 import { useQueryParamsEffect } from '../../containers/useQueryParamsEffect';
-import { Filtering, IFilterOptions } from '../Filtering/Filtering';
-import { Toolbar } from '../Toolbar/Toolbar';
 import { useTitle } from '../../containers/useTitle';
+
+import { projectService } from '../../services/projectService';
+
 import { PageTitles } from '../../utils/PageTitles';
+
 import { ActionButton } from '../ActionButton/ActionButton';
+import { Filtering, IFilterOptions } from '../Filtering/Filtering';
+import { Pagination } from '../Pagination/Pagination';
 import { ProtectedComponent } from '../ProtectedContent/ProtectedComponent';
+import { Toolbar } from '../Toolbar/Toolbar';
+import { PageLayout } from './../PageLayout/PageLayout';
+import { ProjectsList } from './../ProjectsList/ProjectsList';
 
 interface IProjectPage {
   componentId?: string;

--- a/src/components/ProjectsPage/ProjectsPage.tsx
+++ b/src/components/ProjectsPage/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { Label, ToolbarItem } from '@patternfly/react-core';
+import { Flex, FlexItem, Label, ToolbarItem } from '@patternfly/react-core';
 
 import { DataContainer } from '../../containers/DataContainer/DataContainer';
 import { IService, useDataContainer } from '../../containers/DataContainer/useDataContainer';

--- a/src/components/ProjectsPage/__tests__/ProjectsPage.test.tsx
+++ b/src/components/ProjectsPage/__tests__/ProjectsPage.test.tsx
@@ -1,7 +1,8 @@
 import { act } from '@testing-library/react';
-import { ProjectsPage } from '../ProjectsPage';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+
+import { ProjectsPage } from '../ProjectsPage';
 
 jest.mock('../../../services/projectService');
 jest.mock('../../../services/keycloakService');

--- a/src/components/ProtectedContent/ProtectedComponent.tsx
+++ b/src/components/ProtectedContent/ProtectedComponent.tsx
@@ -1,5 +1,6 @@
 import { AUTH_ROLE } from '../../services/keycloakService';
-import { ProtectedContent, PROTECTED_TYPE } from './ProtectedContent';
+
+import { PROTECTED_TYPE, ProtectedContent } from './ProtectedContent';
 
 interface IProtectedComponentProps {
   role?: AUTH_ROLE;

--- a/src/components/ProtectedContent/ProtectedContent.tsx
+++ b/src/components/ProtectedContent/ProtectedContent.tsx
@@ -1,4 +1,5 @@
 import { AUTH_ROLE, keycloakService } from '../../services/keycloakService';
+
 import { ErrorPage } from '../ErrorPage/ErrorPage';
 import styles from './ProtectedContent.module.css';
 

--- a/src/components/ProtectedContent/ProtectedRoute.tsx
+++ b/src/components/ProtectedContent/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { AUTH_ROLE } from '../../services/__mocks__/keycloakService';
-import { ProtectedContent, PROTECTED_TYPE } from './ProtectedContent';
+
+import { PROTECTED_TYPE, ProtectedContent } from './ProtectedContent';
 
 interface IProtectedRouteProps {
   role?: AUTH_ROLE;

--- a/src/components/ScmRepositoriesPage/ScmRepositoriesPage.tsx
+++ b/src/components/ScmRepositoriesPage/ScmRepositoriesPage.tsx
@@ -1,5 +1,7 @@
-import { Divider, PageSection, PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
+import { Divider, PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
+
 import { useTitle } from '../../containers/useTitle';
+
 import { PageTitles } from '../../utils/PageTitles';
 
 export const ScmRepositoriesPage = () => {

--- a/src/components/ScmRepositoriesPage/__tests__/ScmRepositoriesPage.test.tsx
+++ b/src/components/ScmRepositoriesPage/__tests__/ScmRepositoriesPage.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { ScmRepositoriesPage } from '../ScmRepositoriesPage';
 
 test('renders ScmRepositoriesPage', () => {

--- a/src/components/SectionHeader/SectionHeader.tsx
+++ b/src/components/SectionHeader/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, TextVariants, TextContent, FlexProps } from '@patternfly/react-core';
+import { Flex, FlexProps, Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 interface ISectionHeaderProps {
   children?: React.ReactNode;

--- a/src/components/SectionHeader/__tests__/SectionHeader.test.tsx
+++ b/src/components/SectionHeader/__tests__/SectionHeader.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+
 import { SectionHeader } from '../SectionHeader';
 
 test('renders SectionHeader', () => {

--- a/src/components/SystemErrorPage/SystemErrorPage.tsx
+++ b/src/components/SystemErrorPage/SystemErrorPage.tsx
@@ -1,4 +1,4 @@
-import { Title, EmptyState, EmptyStateIcon, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 
 export const SystemErrorPage = () => {

--- a/src/components/SystemErrorPage/__tests__/SystemErrorPage.test.tsx
+++ b/src/components/SystemErrorPage/__tests__/SystemErrorPage.test.tsx
@@ -1,5 +1,6 @@
-import { SystemErrorPage } from '../SystemErrorPage';
 import { render } from '@testing-library/react';
+
+import { SystemErrorPage } from '../SystemErrorPage';
 
 test('renders SystemErrorPage', () => {
   render(<SystemErrorPage />);

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,5 +1,6 @@
+import { ToolbarContent, Toolbar as ToolbarPF } from '@patternfly/react-core';
 import React from 'react';
-import { Toolbar as ToolbarPF, ToolbarContent } from '@patternfly/react-core';
+
 import styles from './Toolbar.module.css';
 
 interface IToolbarProps {}

--- a/src/components/VariablesPage/VariablesPage.tsx
+++ b/src/components/VariablesPage/VariablesPage.tsx
@@ -1,7 +1,10 @@
-import { PageLayout } from '../PageLayout/PageLayout';
-import { CodeBlock, CodeBlockCode, Card, CardTitle, CardBody, Flex, FlexItem } from '@patternfly/react-core';
-import * as WebConfigAPI from '../../services/WebConfigService';
+import { Card, CardBody, CardTitle, CodeBlock, CodeBlockCode, Flex, FlexItem } from '@patternfly/react-core';
+
 import { useTitle } from '../../containers/useTitle';
+
+import * as WebConfigAPI from '../../services/WebConfigService';
+
+import { PageLayout } from '../PageLayout/PageLayout';
 
 // ENVIRONMENTS
 const ProcessEnv = () => <>{JSON.stringify(process.env, null, 2)}</>;

--- a/src/containers/DataContainer/ServiceContainerCreating.tsx
+++ b/src/containers/DataContainer/ServiceContainerCreating.tsx
@@ -1,6 +1,8 @@
 import { Alert } from '@patternfly/react-core';
 import React from 'react';
+
 import { RefreshStateCard } from '../../components/EmptyStates/RefreshStateCard';
+
 import { IDataContainer } from './DataContainer';
 
 export const ServiceContainerCreating = ({ loading, error, children }: React.PropsWithChildren<IDataContainer>) => {

--- a/src/containers/useForm.ts
+++ b/src/containers/useForm.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
 import { TextInputProps } from '@patternfly/react-core';
+import { useCallback, useEffect, useState } from 'react';
 
 interface IFieldValues {
   [key: string]: string | undefined;

--- a/src/containers/useInterval.ts
+++ b/src/containers/useInterval.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect, MutableRefObject, useCallback } from 'react';
+import { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 
 /**
  * React hook for setting up and using intervals.

--- a/src/containers/useQueryParamsEffect.ts
+++ b/src/containers/useQueryParamsEffect.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
-import { queryParamsObjectsAreEqual, getComponentQueryParamsObject } from '../utils/queryParamsHelper';
+
+import { getComponentQueryParamsObject, queryParamsObjectsAreEqual } from '../utils/queryParamsHelper';
 
 export const useQueryParamsEffect = (service: Function, componentId: string) => {
   const lastQueryParams = useRef({});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
+import { BrowserRouter } from 'react-router-dom';
+
+import { ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
+
+import { keycloakService } from './services/keycloakService';
+
 import { AppLayout } from './AppLayout';
 import { AppRoutes } from './AppRoutes';
+import './index.css';
 import reportWebVitals from './reportWebVitals';
-import { BrowserRouter } from 'react-router-dom';
-import { ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
-import { keycloakService } from './services/keycloakService';
 
 const App = () => {
   const [isKeycloakInitiated, setIsKeycloakInitiated] = useState<boolean>(false);

--- a/src/services/__mocks__/pncClient.ts
+++ b/src/services/__mocks__/pncClient.ts
@@ -1,8 +1,9 @@
 import axios, { AxiosInstance } from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+
 import buildsRequestMock from './builds-mock.json';
-import projectsRequestMock from './projects-mock.json';
 import projectRequestMock from './project-mock.json';
+import projectsRequestMock from './projects-mock.json';
 
 let mockAdapter = new MockAdapter(axios);
 

--- a/src/services/buildService.ts
+++ b/src/services/buildService.ts
@@ -1,4 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
+
 import { kafkaClient } from './kafkaClient';
 import { pncClient } from './pncClient';
 

--- a/src/services/kafkaClient.ts
+++ b/src/services/kafkaClient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+
 import * as WebConfigAPI from './WebConfigService';
 
 /**

--- a/src/services/keycloakService.ts
+++ b/src/services/keycloakService.ts
@@ -1,5 +1,6 @@
 import * as WebConfigAPI from '../services/WebConfigService';
 import { Keycloak } from '../services/keycloakHolder';
+
 /**
  * Enum with possible authentication roles in Keycloak.
  *

--- a/src/services/pncClient.ts
+++ b/src/services/pncClient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+
 import * as WebConfigAPI from './WebConfigService';
 import { keycloakService } from './keycloakService';
 

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -1,5 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
+
 import { Project } from 'pnc-api-types-ts';
+
 import { pncClient } from './pncClient';
 
 export interface IProjectServiceData {

--- a/src/utils/queryParamsHelper.ts
+++ b/src/utils/queryParamsHelper.ts
@@ -1,4 +1,4 @@
-import { NavigateFunction, Location } from 'react-router-dom';
+import { Location, NavigateFunction } from 'react-router-dom';
 
 /*
  * URL Query Params are considered to be the Single Point of Truth.


### PR DESCRIPTION
For now, trivago's prettier sort imports plugin was installed and Prettier config was changed to use it.
https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports

It should be decided which order suits best and then applied to all files.