### PR TITLE
[NCL-7619] Implement better way to detect current page route

### DIFF
--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -19,7 +19,7 @@ BreadcrumbItem,*/
 } from '@patternfly/react-core';
 import { BellIcon, CaretDownIcon, CogIcon, OutlinedQuestionCircleIcon, UserIcon } from '@patternfly/react-icons';
 import { useEffect, useState } from 'react';
-import { Link, Outlet, useLocation } from 'react-router-dom';
+import { Link, Outlet, useMatches } from 'react-router-dom';
 
 import { useResizeObserver } from 'hooks/useResizeObserver';
 
@@ -187,7 +187,7 @@ export const AppLayout = () => {
   const AppHeader = <PageHeader logo={<AppLogoImage />} headerTools={<AppHeaderTools />} showNavToggle />;
 
   const AppNavigation = () => {
-    const { pathname } = useLocation();
+    const pathname = useMatches()[1].pathname; //1 index = 2nd match which contains the first part of the path
 
     return (
       <Nav>

--- a/src/__tests__/AppLayout.test.tsx
+++ b/src/__tests__/AppLayout.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
+import * as routeData from 'react-router';
 import { MemoryRouter } from 'react-router-dom';
 import ResizeObserver from 'resize-observer-polyfill';
 
@@ -21,6 +22,14 @@ window.pnc = {
   },
 };
 
+const mockMatches = [
+  { id: '0', pathname: '/', data: 'data', handle: '1', params: {} },
+  { id: '0-1', pathname: '/products', data: 'data', handle: '2', params: {} },
+];
+
+beforeEach(() => {
+  jest.spyOn(routeData, 'useMatches').mockReturnValue(mockMatches);
+});
 test('renders AppLayout', async () => {
   act(() => {
     render(


### PR DESCRIPTION
I used useMatches as it was easy to pick correct part of the path without some manual string parsing
![matches](https://github.com/project-ncl/pnc-web-ui-react/assets/5735284/f0faeb1e-6aae-47e7-a04c-c02067c9e28e)
first 2 matches should always be there and I'm using second one to determine where user is and which nav tab should be active.

BTW I have no idea if we want to test AppLayout in the way it is tested but it is testing something.