### PR TITLE
[NCL-8280] Fix overflow issue for attributes names

### DIFF
--- a/src/components/Attributes/Attributes.module.css
+++ b/src/components/Attributes/Attributes.module.css
@@ -1,5 +1,6 @@
 .name {
   font-weight: bold;
+  word-break: break-word;
 }
 
 .minmax-grid {


### PR DESCRIPTION
The root cause is that responsive column calculation won't work for the build config details page which has a sidebar. I fixed it by applying `word-break: break-word;' for all attribute names, because this works for both break-word(when break by word is good enough) and break-all mode(when break-word is not enough, it will break all) 

See jira comments for screenshots.