### PR TITLE
[NCL-8836] Update demo cases for dependency list and build metrics

### DIFF
--- a/src/components/DemoPage/DemoPage.tsx
+++ b/src/components/DemoPage/DemoPage.tsx
@@ -156,7 +156,7 @@ const initLogData = [
 ];
 
 const DEPENDENCY_TREE_ROOT_BUILD: Build = {
-  id: 'ATFZH3MH4TIAG',
+  id: '16740',
   submitTime: '2017-12-01T13:17:18.007Z',
   status: 'REJECTED_FAILED_DEPENDENCIES',
   buildConfigRevision: {
@@ -170,7 +170,7 @@ const DEPENDENCY_TREE_ROOT_BUILD: Build = {
 };
 
 const DEPENDENCY_TREE_ROOT_GROUP_BUILD: GroupBuild = {
-  id: '754',
+  id: '3198',
   status: 'REJECTED_FAILED_DEPENDENCIES',
   groupConfig: {
     id: '166',

--- a/src/components/DemoPage/data/mock-build-data.json
+++ b/src/components/DemoPage/data/mock-build-data.json
@@ -1,41 +1,41 @@
 [
   {
-    "id": "AQSXEDCOMNAAA",
+    "id": "BCNPKKWYILYAA",
     "submitTime": "2022-03-01T13:26:36.521Z",
     "buildConfigRevision": {
       "id": "3601"
     }
   },
   {
-    "id": "AQSV66MM4NAAA",
+    "id": "BCNPAO5QILYAA",
     "submitTime": "2022-03-02T13:26:36.521Z",
     "buildConfigRevision": {
       "id": "3602"
     }
   },
   {
-    "id": "AQSVYX4DMNAAA",
+    "id": "BC4WE2BXVZYAA",
     "submitTime": "2022-03-03T13:26:36.521Z",
     "buildConfigRevision": {
       "id": "3603"
     }
   },
   {
-    "id": "AQSUYN6LENAAA",
+    "id": "BCZAHHHDFZYAA",
     "submitTime": "2022-03-04T13:26:36.521Z",
     "buildConfigRevision": {
       "id": "3604"
     }
   },
   {
-    "id": "AQSUVNLJ4NAAA",
+    "id": "AR3PIBFH7EAAA",
     "submitTime": "2022-03-05T13:26:36.521Z",
     "buildConfigRevision": {
       "id": "3605"
     }
   },
   {
-    "id": "AQQY3LIVMNAAA",
+    "id": "AR3PIBFH7EAAA",
     "submitTime": "2022-03-06T13:26:36.521Z",
     "buildConfigRevision": {
       "id": "3606"


### PR DESCRIPTION
For the dependency tree, I found build and group build IDs that are available from both stage and prod env(it is really hard to find it for dev env as we lost those builds with number IDs during OCP outages)

For build metrics, I picked 2 builds from each env so that the user can at least see 2 demo builds from each environment.